### PR TITLE
Feat: Create Development Database Seed Script

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,35 @@ curl -X DELETE http://localhost:3000/users/1
 5. **Test APIs**:
    Use the `curl` commands in the API Documentation section to verify endpoints.
 
+## Seeded Users
+
+Populate the local database with test users by running:
+
+```bash
+npm run seed:dev
+```
+
+The script is idempotent — re-running it skips users that already exist.  
+To wipe the users table first and start fresh:
+
+```bash
+npm run seed:dev -- --fresh
+```
+
+> ⚠️ The script refuses to run when `NODE_ENV=production`.
+
+### Test credentials
+
+| Name        | Email                  | Password        | Role (future) |
+|-------------|------------------------|-----------------|---------------|
+| Fan One     | fan1@dev.local         | Fan1Pass!       | fan           |
+| Fan Two     | fan2@dev.local         | Fan2Pass!       | fan           |
+| Creator One | creator1@dev.local     | Creator1Pass!   | creator       |
+| Creator Two | creator2@dev.local     | Creator2Pass!   | creator       |
+| Admin       | admin@dev.local        | AdminPass!      | admin         |
+
+These credentials are **development-only** and must never be used in production.
+
 ## Contributing
 
 1. Fork the repository.

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json",
-    "migration-c": "sh -c 'npx typeorm migration:create src/migrations/$1' --"
+    "migration-c": "sh -c 'npx typeorm migration:create src/migrations/$1' --",
+    "seed:dev": "ts-node -r tsconfig-paths/register src/seeds/seed.ts"
   },
   "dependencies": {
     "@nestjs/common": "^11.0.1",

--- a/src/seeds/seed.ts
+++ b/src/seeds/seed.ts
@@ -1,0 +1,60 @@
+import 'reflect-metadata';
+import { config } from 'dotenv';
+import { DataSource } from 'typeorm';
+import * as bcrypt from 'bcrypt';
+import { User } from '../users/user.entity';
+
+config();
+
+if (process.env.NODE_ENV === 'production') {
+  console.error('Seed script must not run in production.');
+  process.exit(1);
+}
+
+const dataSource = new DataSource({
+  type: 'postgres',
+  host: process.env.DB_HOST,
+  port: Number(process.env.DB_PORT),
+  username: process.env.DB_USERNAME,
+  password: process.env.DB_PASSWORD,
+  database: process.env.DB_NAME,
+  entities: [User],
+  synchronize: false,
+});
+
+const SEED_USERS = [
+  { name: 'Fan One',     email: 'fan1@dev.local',     password: 'Fan1Pass!' },
+  { name: 'Fan Two',     email: 'fan2@dev.local',     password: 'Fan2Pass!' },
+  { name: 'Creator One', email: 'creator1@dev.local', password: 'Creator1Pass!' },
+  { name: 'Creator Two', email: 'creator2@dev.local', password: 'Creator2Pass!' },
+  { name: 'Admin',       email: 'admin@dev.local',    password: 'AdminPass!' },
+];
+
+async function seed() {
+  await dataSource.initialize();
+  const repo = dataSource.getRepository(User);
+
+  if (process.argv.includes('--fresh')) {
+    await repo.query('TRUNCATE TABLE users RESTART IDENTITY CASCADE');
+    console.log('Users table truncated.');
+  }
+
+  for (const u of SEED_USERS) {
+    const exists = await repo.findOneBy({ email: u.email });
+    if (exists) {
+      console.log(`Skipped (already exists): ${u.email}`);
+      continue;
+    }
+    const hashed = await bcrypt.hash(u.password, 10);
+    await repo.save(repo.create({ name: u.name, email: u.email, password: hashed }));
+    console.log(`Seeded: ${u.email}`);
+  }
+
+  await dataSource.destroy();
+  console.log('Done.');
+}
+
+seed().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
Closes #14 

The development database seed script has been developed. Here's a summary of everything added:         
                                                      
  `src/seeds/seed.ts`                                 
                                                      
  - Builds a standalone TypeORM DataSource from .env  
   (no NestJS bootstrap required)                     
  - Guards against NODE_ENV=production at startup     
  - Seeds 5 users (2 fans, 2 creators, 1 admin) with  
  bcrypt-hashed passwords                             
  - Skip-if-exists logic on email makes it fully      
  idempotent                                          
  - --fresh flag truncates the users table before     
  seeding                                             
                                                      
  `package.json`                                      
                                                      
  "seed:dev": "ts-node -r tsconfig-paths/register     
  src/seeds/seed.ts"                                  
                                                      
  -Uses tsconfig-paths to honour the baseUrl: "./" path
  alias so the User entity import resolves correctly. 
                                                      
  `README.md` — new "Seeded Users" section with:      
                                                      
  - npm run seed:dev and npm run seed:dev -- --fresh  
   usage                                              
  - Table of all 5 test emails/passwords              
  - Warning that these credentials are dev-only  