### PR TITLE
feat: extend user profile fields & validation

### DIFF
--- a/src/migrations/1750254051000-AddUserProfileFields.ts
+++ b/src/migrations/1750254051000-AddUserProfileFields.ts
@@ -1,0 +1,39 @@
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+
+export class AddUserProfileFields1750254051000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.addColumn(
+      'users',
+      new TableColumn({
+        name: 'displayName',
+        type: 'varchar',
+        isNullable: true,
+      }),
+    );
+
+    await queryRunner.addColumn(
+      'users',
+      new TableColumn({
+        name: 'bio',
+        type: 'varchar',
+        length: '300',
+        isNullable: true,
+      }),
+    );
+
+    await queryRunner.addColumn(
+      'users',
+      new TableColumn({
+        name: 'avatarUrl',
+        type: 'varchar',
+        isNullable: true,
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropColumn('users', 'avatarUrl');
+    await queryRunner.dropColumn('users', 'bio');
+    await queryRunner.dropColumn('users', 'displayName');
+  }
+}

--- a/src/users/dtos/createUser.dto.ts
+++ b/src/users/dtos/createUser.dto.ts
@@ -1,11 +1,18 @@
 import { Expose } from 'class-transformer';
+import { IsEmail, IsString, MinLength } from 'class-validator';
 
 export class CreateUserDto {
   @Expose()
+  @IsString()
   name!: string;
+
   @Expose()
+  @IsEmail()
   email!: string;
+
   @Expose()
+  @IsString()
+  @MinLength(8)
   password!: string;
 
   constructor(name: string, email: string, password: string) {

--- a/src/users/dtos/updateProfile.dto.ts
+++ b/src/users/dtos/updateProfile.dto.ts
@@ -1,0 +1,23 @@
+import { IsOptional, IsString, IsUrl, MaxLength } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+export class UpdateProfileDto {
+  @ApiPropertyOptional({ description: 'Display name for the user' })
+  @IsOptional()
+  @IsString()
+  displayName?: string;
+
+  @ApiPropertyOptional({
+    description: 'Short bio (max 300 characters)',
+    maxLength: 300,
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(300)
+  bio?: string;
+
+  @ApiPropertyOptional({ description: 'URL to the user avatar image' })
+  @IsOptional()
+  @IsUrl()
+  avatarUrl?: string;
+}

--- a/src/users/dtos/userResponse.dto.ts
+++ b/src/users/dtos/userResponse.dto.ts
@@ -28,6 +28,15 @@ export class UserResponseDto {
   updated_at: Date;
 
   @Expose()
+  displayName?: string | null;
+
+  @Expose()
+  bio?: string | null;
+
+  @Expose()
+  avatarUrl?: string | null;
+
+  @Expose()
   message?: string;
 
   @Expose()

--- a/src/users/updateProfile.dto.spec.ts
+++ b/src/users/updateProfile.dto.spec.ts
@@ -1,0 +1,51 @@
+import { validate } from 'class-validator';
+import { UpdateProfileDto } from './dtos/updateProfile.dto';
+
+describe('UpdateProfileDto validation', () => {
+  it('should pass with all valid optional fields', async () => {
+    const dto = new UpdateProfileDto();
+    dto.displayName = 'Jane Doe';
+    dto.bio = 'Short bio';
+    dto.avatarUrl = 'https://example.com/avatar.png';
+
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('should pass with no fields (all optional)', async () => {
+    const dto = new UpdateProfileDto();
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('should fail when bio exceeds 300 characters', async () => {
+    const dto = new UpdateProfileDto();
+    dto.bio = 'a'.repeat(301);
+
+    const errors = await validate(dto);
+    expect(errors.some((e) => e.property === 'bio')).toBe(true);
+  });
+
+  it('should pass when bio is exactly 300 characters', async () => {
+    const dto = new UpdateProfileDto();
+    dto.bio = 'a'.repeat(300);
+
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('should fail when avatarUrl is not a valid URL', async () => {
+    const dto = new UpdateProfileDto();
+    dto.avatarUrl = 'not-a-url';
+
+    const errors = await validate(dto);
+    expect(errors.some((e) => e.property === 'avatarUrl')).toBe(true);
+  });
+
+  it('should fail when displayName is not a string', async () => {
+    const dto = Object.assign(new UpdateProfileDto(), { displayName: 123 });
+
+    const errors = await validate(dto);
+    expect(errors.some((e) => e.property === 'displayName')).toBe(true);
+  });
+});

--- a/src/users/user.entity.ts
+++ b/src/users/user.entity.ts
@@ -48,4 +48,13 @@ export class User {
 
   @Column({ type: 'tsvector', nullable: true })
   search_text: string;
+
+  @Column({ type: 'varchar', nullable: true })
+  displayName?: string | null;
+
+  @Column({ type: 'varchar', length: 300, nullable: true })
+  bio?: string | null;
+
+  @Column({ type: 'varchar', nullable: true })
+  avatarUrl?: string | null;
 }

--- a/src/users/users.controller.spec.ts
+++ b/src/users/users.controller.spec.ts
@@ -20,6 +20,7 @@ describe('UsersController', () => {
             getUserById: jest.fn(),
             createUser: jest.fn(),
             updateUser: jest.fn(),
+            updateProfile: jest.fn(),
             deleteUser: jest.fn(),
           },
         },
@@ -246,6 +247,36 @@ describe('UsersController', () => {
 
       expect(result).toBe(message);
       expect(service.deleteUser).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe('updateProfile', () => {
+    it('should update profile fields', async () => {
+      const profileDto = {
+        displayName: 'Jane',
+        bio: 'My bio',
+        avatarUrl: 'https://example.com/avatar.png',
+      };
+
+      const mockUpdated: UserResponseDto = {
+        id: 1,
+        name: 'John Doe',
+        email: 'john@example.com',
+        role: 'user',
+        status: 'active',
+        created_at: new Date(),
+        updated_at: new Date(),
+        displayName: 'Jane',
+        bio: 'My bio',
+        avatarUrl: 'https://example.com/avatar.png',
+      };
+
+      (service.updateProfile as jest.Mock).mockResolvedValue(mockUpdated);
+
+      const result = await controller.updateProfile(1, profileDto);
+
+      expect(result).toEqual(mockUpdated);
+      expect(service.updateProfile).toHaveBeenCalledWith(1, profileDto);
     });
   });
 });

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -4,6 +4,7 @@ import {
   Delete,
   Get,
   Param,
+  Patch,
   Post,
   Put,
   UseGuards,
@@ -13,6 +14,7 @@ import {
 } from '@nestjs/common';
 import { UsersService } from './users.service';
 import { CreateUserDto } from './dtos/createUser.dto';
+import { UpdateProfileDto } from './dtos/updateProfile.dto';
 import { UserResponseDto } from './dtos/userResponse.dto';
 import { GetUsersQueryDto } from './dtos/get-users-query.dto';
 import { PaginatedResponseDto } from './dtos/paginated-response.dto';
@@ -24,6 +26,7 @@ import {
   ApiBearerAuth,
   ApiParam,
   ApiQuery,
+  ApiBody,
 } from '@nestjs/swagger';
 
 interface CurrentUser {
@@ -233,5 +236,27 @@ export class UsersController {
     @Body() updateUserDto: CreateUserDto,
   ): Promise<UserResponseDto> {
     return this.usersService.updateUser(id, updateUserDto);
+  }
+
+  @Patch(':id/profile')
+  @ApiOperation({ summary: 'Partially update user profile fields' })
+  @ApiParam({ name: 'id', description: 'User ID' })
+  @ApiBody({ type: UpdateProfileDto })
+  @ApiResponse({
+    status: 200,
+    description: 'Profile updated successfully',
+    type: UserResponseDto,
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Validation error (e.g. bio too long, invalid URL)',
+  })
+  @ApiResponse({ status: 404, description: 'User not found' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  async updateProfile(
+    @Param('id') id: number,
+    @Body() updateProfileDto: UpdateProfileDto,
+  ): Promise<UserResponseDto> {
+    return this.usersService.updateProfile(id, updateProfileDto);
   }
 }

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -11,6 +11,7 @@ import { CreateUserDto } from './dtos/createUser.dto';
 import { UserResponseDto } from './dtos/userResponse.dto';
 import { plainToInstance } from 'class-transformer';
 import { UpdateUserDto } from './dtos/updateUser.dto';
+import { UpdateProfileDto } from './dtos/updateProfile.dto';
 import { GetUsersQueryDto } from './dtos/get-users-query.dto';
 import {
   PaginatedResponseDto,
@@ -171,6 +172,25 @@ export class UsersService {
         excludeExtraneousValues: true,
       },
     );
+  }
+
+  async updateProfile(
+    id: number,
+    updateProfileDto: UpdateProfileDto,
+  ): Promise<UserResponseDto> {
+    const user: User | null = await this.findById(id);
+    if (!user) {
+      throw new NotFoundException('user not found');
+    }
+
+    Object.assign(user, updateProfileDto);
+    const savedUser: User = await this.userRepository.save(user);
+
+    await this.invalidateUserRelatedCaches(savedUser.id);
+
+    return plainToInstance(UserResponseDto, savedUser, {
+      excludeExtraneousValues: true,
+    });
   }
 
   private async invalidateUserRelatedCaches(userId: number): Promise<void> {


### PR DESCRIPTION
Closes #16 

new changes to the codebase:
this PR:
- Add optional displayName, bio (max 300 chars), avatarUrl fields to User entity
- Add migration 1750254051000-AddUserProfileFields for new nullable columns
- Add IsEmail and MinLength(8) validation to CreateUserDto
- Create UpdateProfileDto with IsOptional/IsString/MaxLength/IsUrl decorators
- Expose displayName, bio, avatarUrl in UserResponseDto (password never returned)
- Add UsersService.updateProfile() for partial profile updates
- Add PATCH /users/:id/profile route with Swagger docs
- Add unit tests: validation failures (bio too long, invalid URL, bad displayName type)
- Add controller test for updateProfile endpoint