### PR TITLE
feat:E2E Tests for Auth and Users Endpoints Overview

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,28 @@ on:
 jobs:
   checks:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_DB: my_fans_test
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d my_fans_test"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      TEST_DB_HOST: 127.0.0.1
+      TEST_DB_PORT: 5432
+      TEST_DB_NAME: my_fans_test
+      TEST_DB_USERNAME: postgres
+      TEST_DB_PASSWORD: postgres
+      TEST_JWT_SECRET: ci-test-jwt-secret
+      TEST_JWT_EXPIRES_IN: 1h
 
     steps:
       - name: Checkout
@@ -28,6 +50,9 @@ jobs:
 
       - name: Unit tests
         run: npm test
+
+      - name: E2E tests
+        run: npm run test:e2e
 
       - name: Build
         run: npm run build

--- a/README.md
+++ b/README.md
@@ -129,6 +129,40 @@ curl -X DELETE http://localhost:3000/users/1
 5. **Test APIs**:
    Use the `curl` commands in the API Documentation section to verify endpoints.
 
+### Running Tests
+
+Run the unit test suite:
+
+```bash
+npm test
+```
+
+Run the end-to-end suite:
+
+```bash
+npm run test:e2e
+```
+
+The e2e suite uses a dedicated PostgreSQL test database and does not read your normal `DB_*` variables. By default it connects to:
+
+```env
+TEST_DB_HOST=127.0.0.1
+TEST_DB_PORT=5432
+TEST_DB_NAME=my_fans_test
+TEST_DB_USERNAME=postgres
+TEST_DB_PASSWORD=postgres
+TEST_JWT_SECRET=test-jwt-secret
+TEST_JWT_EXPIRES_IN=1h
+```
+
+Create the database once before running locally:
+
+```bash
+createdb -h 127.0.0.1 -U postgres my_fans_test
+```
+
+Override the `TEST_DB_*` variables if your local PostgreSQL user, password, host, or port differs. Test data is truncated between specs.
+
 ## Seeded Users
 
 Populate the local database with test users by running:

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -78,7 +78,6 @@ export class UsersService {
   }
 
   async createUser(createUserDto: CreateUserDto): Promise<UserResponseDto> {
-    console.log('createUserDto', createUserDto);
     let searchUser: User | null = await this.getUserByEmail(
       createUserDto.email,
     );

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -1,23 +1,19 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { INestApplication } from '@nestjs/common';
 import * as request from 'supertest';
-import { App } from 'supertest/types';
-import { AppModule } from './../src/app.module';
+import { createE2eApp, E2eTestApp } from './helpers/e2e-app';
 
 describe('AppController (e2e)', () => {
-  let app: INestApplication<App>;
+  let testApp: E2eTestApp;
 
-  beforeEach(async () => {
-    const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [AppModule],
-    }).compile();
+  beforeAll(async () => {
+    testApp = await createE2eApp();
+  });
 
-    app = moduleFixture.createNestApplication();
-    await app.init();
+  afterAll(async () => {
+    await testApp.app.close();
   });
 
   it('/ (GET)', () => {
-    return request(app.getHttpServer())
+    return request(testApp.app.getHttpServer())
       .get('/')
       .expect(200)
       .expect('Hello World!');

--- a/test/auth.e2e-spec.ts
+++ b/test/auth.e2e-spec.ts
@@ -1,0 +1,101 @@
+import * as request from 'supertest';
+import { clearDatabase, createE2eApp, E2eTestApp } from './helpers/e2e-app';
+import {
+  buildSignupPayload,
+  loginUser,
+  signupUser,
+  TEST_PASSWORD,
+} from './helpers/auth';
+
+describe('Auth E2E', () => {
+  let testApp: E2eTestApp;
+
+  beforeAll(async () => {
+    testApp = await createE2eApp();
+  });
+
+  beforeEach(async () => {
+    await clearDatabase(testApp.dataSource);
+  });
+
+  afterAll(async () => {
+    await testApp.app.close();
+  });
+
+  describe('POST /auth/signup', () => {
+    it('creates a user and returns a token without exposing the password', async () => {
+      const payload = buildSignupPayload({
+        name: 'Signup User',
+        email: 'signup@example.com',
+      });
+
+      const response = await request(testApp.app.getHttpServer())
+        .post('/auth/signup')
+        .send(payload)
+        .expect(201);
+
+      expect(response.body.access_token).toEqual(expect.any(String));
+      expect(response.body.expires_in).toBe('1h');
+      expect(response.body.message).toBe('user created successfully...');
+      expect(response.body.user).toMatchObject({
+        id: 1,
+        name: payload.name,
+        email: payload.email,
+      });
+      expect(response.body.user).not.toHaveProperty('password');
+    });
+
+    it('rejects duplicate email signup', async () => {
+      const payload = buildSignupPayload({
+        email: 'duplicate@example.com',
+      });
+
+      await request(testApp.app.getHttpServer())
+        .post('/auth/signup')
+        .send(payload)
+        .expect(201);
+
+      const response = await request(testApp.app.getHttpServer())
+        .post('/auth/signup')
+        .send(payload)
+        .expect(409);
+
+      expect(response.body.message).toBe('user already exists with this email');
+    });
+  });
+
+  describe('POST /auth/login', () => {
+    it('logs in an existing user and returns a bearer token payload', async () => {
+      const { payload, user: signupUserResponse } = await signupUser(
+        testApp.app,
+        {
+          name: 'Login User',
+          email: 'login@example.com',
+        },
+      );
+
+      const { token, user } = await loginUser(
+        testApp.app,
+        payload.email,
+        TEST_PASSWORD,
+      );
+
+      expect(token).toEqual(expect.any(String));
+      expect(user).toEqual(signupUserResponse);
+      expect(user.email).toBe(payload.email);
+    });
+
+    it('rejects invalid login credentials', async () => {
+      const { payload } = await signupUser(testApp.app, {
+        email: 'invalid-login@example.com',
+      });
+
+      const response = await request(testApp.app.getHttpServer())
+        .post('/auth/login')
+        .send({ email: payload.email, password: 'WrongPassword123!' })
+        .expect(401);
+
+      expect(response.body.message).toBe('Invalid credentials');
+    });
+  });
+});

--- a/test/helpers/auth.ts
+++ b/test/helpers/auth.ts
@@ -1,0 +1,73 @@
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+
+export const TEST_PASSWORD = 'Password123!';
+
+export interface SignupPayload {
+  name: string;
+  email: string;
+  password: string;
+}
+
+export interface AuthResult {
+  payload: SignupPayload;
+  token: string;
+  user: {
+    id: number;
+    name: string;
+    email: string;
+  };
+}
+
+export function buildSignupPayload(
+  overrides: Partial<SignupPayload> = {},
+): SignupPayload {
+  return {
+    name: 'Test User',
+    email: `user.${Date.now()}.${Math.random().toString(36).slice(2)}@example.com`,
+    password: TEST_PASSWORD,
+    ...overrides,
+  };
+}
+
+export async function signupUser(
+  app: INestApplication,
+  overrides: Partial<SignupPayload> = {},
+): Promise<AuthResult> {
+  const payload = buildSignupPayload(overrides);
+  const response = await request(app.getHttpServer())
+    .post('/auth/signup')
+    .send(payload)
+    .expect(201);
+
+  return {
+    payload,
+    token: response.body.access_token,
+    user: response.body.user,
+  };
+}
+
+export async function loginUser(
+  app: INestApplication,
+  email: string,
+  password = TEST_PASSWORD,
+): Promise<AuthResult> {
+  const response = await request(app.getHttpServer())
+    .post('/auth/login')
+    .send({ email, password })
+    .expect(201);
+
+  return {
+    payload: {
+      name: response.body.user.name,
+      email,
+      password,
+    },
+    token: response.body.access_token,
+    user: response.body.user,
+  };
+}
+
+export function bearerToken(token: string): string {
+  return `Bearer ${token}`;
+}

--- a/test/helpers/e2e-app.ts
+++ b/test/helpers/e2e-app.ts
@@ -1,0 +1,42 @@
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { DataSource, Repository } from 'typeorm';
+import { AppModule } from '../../src/app.module';
+import { User } from '../../src/users/user.entity';
+
+export interface E2eTestApp {
+  app: INestApplication;
+  moduleFixture: TestingModule;
+  dataSource: DataSource;
+  userRepository: Repository<User>;
+}
+
+export async function createE2eApp(): Promise<E2eTestApp> {
+  const moduleFixture = await Test.createTestingModule({
+    imports: [AppModule],
+  }).compile();
+
+  const app = moduleFixture.createNestApplication();
+  app.useGlobalPipes(
+    new ValidationPipe({
+      whitelist: true,
+      forbidNonWhitelisted: true,
+      transform: true,
+    }),
+  );
+  await app.init();
+
+  return {
+    app,
+    moduleFixture,
+    dataSource: moduleFixture.get(DataSource),
+    userRepository: moduleFixture.get<Repository<User>>(
+      getRepositoryToken(User),
+    ),
+  };
+}
+
+export async function clearDatabase(dataSource: DataSource): Promise<void> {
+  await dataSource.query('TRUNCATE TABLE "users" RESTART IDENTITY CASCADE');
+}

--- a/test/jest-e2e.json
+++ b/test/jest-e2e.json
@@ -3,6 +3,12 @@
   "rootDir": ".",
   "testEnvironment": "node",
   "testRegex": ".e2e-spec.ts$",
+  "setupFiles": ["<rootDir>/setup-e2e.ts"],
+  "moduleNameMapper": {
+    "^src/(.*)$": "<rootDir>/../src/$1"
+  },
+  "maxWorkers": 1,
+  "testTimeout": 30000,
   "transform": {
     "^.+\\.(t|j)s$": "ts-jest"
   }

--- a/test/setup-e2e.ts
+++ b/test/setup-e2e.ts
@@ -1,0 +1,10 @@
+process.env.NODE_ENV = 'test';
+
+process.env.DB_HOST = process.env.TEST_DB_HOST ?? '127.0.0.1';
+process.env.DB_PORT = process.env.TEST_DB_PORT ?? '5432';
+process.env.DB_NAME = process.env.TEST_DB_NAME ?? 'my_fans_test';
+process.env.DB_USERNAME = process.env.TEST_DB_USERNAME ?? 'postgres';
+process.env.DB_PASSWORD = process.env.TEST_DB_PASSWORD ?? 'postgres';
+
+process.env.JWT_SECRET = process.env.TEST_JWT_SECRET ?? 'test-jwt-secret';
+process.env.JWT_EXPIRES_IN = process.env.TEST_JWT_EXPIRES_IN ?? '1h';

--- a/test/users.e2e-spec.ts
+++ b/test/users.e2e-spec.ts
@@ -1,0 +1,69 @@
+import * as request from 'supertest';
+import { bearerToken, signupUser } from './helpers/auth';
+import { clearDatabase, createE2eApp, E2eTestApp } from './helpers/e2e-app';
+
+describe('Users E2E', () => {
+  let testApp: E2eTestApp;
+
+  beforeAll(async () => {
+    testApp = await createE2eApp();
+  });
+
+  beforeEach(async () => {
+    await clearDatabase(testApp.dataSource);
+  });
+
+  afterAll(async () => {
+    await testApp.app.close();
+  });
+
+  describe('GET /users/:id', () => {
+    it('returns the signed-up user when called with a valid bearer token', async () => {
+      const { token, user } = await signupUser(testApp.app, {
+        name: 'Protected User',
+        email: 'protected@example.com',
+      });
+
+      const response = await request(testApp.app.getHttpServer())
+        .get(`/users/${user.id}`)
+        .set('Authorization', bearerToken(token))
+        .expect(200);
+
+      expect(response.body).toMatchObject({
+        id: user.id,
+        name: user.name,
+        email: user.email,
+        role: 'user',
+        status: 'active',
+      });
+      expect(response.body).not.toHaveProperty('password');
+      expect(response.body.created_at).toEqual(expect.any(String));
+      expect(response.body.updated_at).toEqual(expect.any(String));
+    });
+
+    it('rejects requests without a bearer token', async () => {
+      const { user } = await signupUser(testApp.app, {
+        email: 'missing-token@example.com',
+      });
+
+      const response = await request(testApp.app.getHttpServer())
+        .get(`/users/${user.id}`)
+        .expect(401);
+
+      expect(response.body.message).toBe('Unauthorized');
+    });
+
+    it('rejects requests with an invalid bearer token', async () => {
+      const { user } = await signupUser(testApp.app, {
+        email: 'invalid-token@example.com',
+      });
+
+      const response = await request(testApp.app.getHttpServer())
+        .get(`/users/${user.id}`)
+        .set('Authorization', 'Bearer invalid.jwt.token')
+        .expect(401);
+
+      expect(response.body.message).toBe('Unauthorized');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #17 

Adds focused end-to-end coverage for auth and JWT-protected user flows, using a dedicated PostgreSQL test database configuration so tests do not depend on production credentials.

## What Changed

- Added `test/auth.e2e-spec.ts` covering:
  - Signup happy path
  - Duplicate email signup failure
  - Login happy path
  - Invalid login failure

- Added `test/users.e2e-spec.ts` covering:
  - Authenticated `GET /users/:id`
  - Missing JWT rejection
  - Invalid JWT rejection

- Added reusable e2e helpers for:
  - Bootstrapping the Nest app
  - Cleaning test data between specs
  - Creating users
  - Logging in and obtaining bearer tokens

- Updated `test/jest-e2e.json` with:
  - Test setup file
  - `src/*` path mapping
  - Serial execution
  - E2E timeout

- Added dedicated test env defaults via `test/setup-e2e.ts`.

- Updated CI to run e2e tests with a PostgreSQL service.

- Documented `npm run test:e2e` and local test database setup in the README.

- Removed a signup DTO console log that exposed password values during tests.

## Acceptance Criteria

- [x] `npm run test:e2e` passes with documented setup
- [x] Tests isolate data between runs
- [x] Unauthorized access to `/users/:id` returns `401`
- [x] Covers signup, login, and JWT-protected user access
- [x] Covers duplicate signup, invalid login, missing JWT, and invalid JWT
- [x] Includes at least 8 meaningful e2e assertions/tests
- [x] Tests use dedicated `TEST_DB_*` config instead of production database credentials
- [x] CI runs unit tests and e2e tests

## Tests

Verified locally:

```bash
npm run format:check
npm test
TEST_DB_PORT=55432 npm run test:e2e
npm run build