### PR TITLE
Implement secure refresh token sessions

### DIFF
--- a/docs/auth-refresh-flow.md
+++ b/docs/auth-refresh-flow.md
@@ -1,0 +1,61 @@
+# Auth Refresh Token Flow
+
+This API issues short-lived access tokens and rotating refresh tokens.
+Access tokens expire after 15 minutes. Refresh tokens expire after 7 days and
+are stored only as bcrypt hashes.
+
+## Token Claims
+
+Both JWT types include:
+
+- `sub`: user id
+- `email`: user email
+- `jti`: unique token id
+- `type`: `access` or `refresh`
+- `iat`: issued-at timestamp
+- `exp`: expiration timestamp
+
+Refresh tokens also include `familyId` and `tokenId` so the backend can rotate
+and revoke a per-device token family.
+
+## Sequence
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant AuthController
+    participant TokenService
+    participant Database
+
+    Client->>AuthController: POST /auth/login
+    AuthController->>TokenService: issueTokenPair(user, device)
+    TokenService->>Database: save bcrypt(refreshToken), familyId, jti, device
+    TokenService-->>AuthController: accessToken + refreshToken
+    AuthController-->>Client: 200 token pair
+
+    Client->>AuthController: POST /auth/refresh(refreshToken)
+    AuthController->>TokenService: rotateRefreshToken(refreshToken)
+    TokenService->>TokenService: verify JWT_REFRESH_SECRET and type=refresh
+    TokenService->>Database: load token row by tokenId
+    TokenService->>TokenService: bcrypt.compare(refreshToken, tokenHash)
+    TokenService->>Database: save new refresh token in same family
+    TokenService->>Database: revoke old token and set replacedByTokenId
+    TokenService-->>AuthController: new accessToken + refreshToken
+    AuthController-->>Client: 200 rotated token pair
+
+    Client->>AuthController: POST /auth/refresh(old revoked token)
+    AuthController->>TokenService: rotateRefreshToken(old token)
+    TokenService->>Database: old row is already revoked
+    TokenService->>Database: revoke all active tokens in family
+    TokenService-->>AuthController: 401 REFRESH_TOKEN_REUSE_DETECTED
+    AuthController-->>Client: 401 with machine-readable code
+```
+
+## Session Endpoints
+
+- `POST /auth/logout` revokes the submitted refresh token only.
+- `POST /auth/logout-all` revokes all active refresh tokens for the current user.
+- `GET /auth/sessions` lists active device sessions without hashes or raw tokens.
+- `DELETE /auth/sessions/:id` revokes one session belonging to the current user.
+
+Password updates revoke all active refresh sessions for that user.

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,42 +1,161 @@
-import { Controller, Post, Body, UnauthorizedException } from '@nestjs/common';
+import {
+  Controller,
+  Post,
+  Body,
+  UnauthorizedException,
+  UseGuards,
+  Get,
+  Delete,
+  Param,
+  Req,
+  NotFoundException,
+  HttpCode,
+} from '@nestjs/common';
+import { Request } from 'express';
 import { AuthService } from './auth.service';
 import { LoginDto } from './dto/login.dto';
 import { SignupDto } from './dto/signup.dto';
-import { ApiTags, ApiOperation, ApiResponse, ApiBody } from '@nestjs/swagger';
+import { RefreshTokenDto } from './dto/refresh-token.dto';
+import { AuthTokensResponseDto } from './dto/auth-tokens-response.dto';
+import { SessionResponseDto } from './dto/session-response.dto';
+import { JwtAuthGuard } from './guards/jwt-auth.guard';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBody,
+  ApiBearerAuth,
+} from '@nestjs/swagger';
+
+interface AuthenticatedRequest extends Request {
+  user: {
+    userId: number;
+    email: string;
+    username: string;
+  };
+}
 
 @ApiTags('Authentication')
 @Controller('auth')
 export class AuthController {
-  constructor(private authService: AuthService) {}
+  constructor(private readonly authService: AuthService) {}
 
   @Post('signup')
-  @ApiOperation({ summary: 'User signup' })
-  @ApiResponse({
-    status: 201,
-    description: 'User successfully created and logged in',
-  })
-  @ApiResponse({
-    status: 409,
-    description: 'User already exists with this email',
-  })
+  @ApiOperation({ summary: 'User signup — returns access + refresh token pair' })
+  @ApiResponse({ status: 201, type: AuthTokensResponseDto })
+  @ApiResponse({ status: 409, description: 'Email already exists' })
   @ApiBody({ type: SignupDto })
-  async signup(@Body() signupDto: SignupDto) {
-    return this.authService.signup(signupDto);
+  async signup(@Body() signupDto: SignupDto, @Req() req: Request) {
+    return this.authService.signup(signupDto, this.extractDeviceInfo(req));
   }
 
   @Post('login')
-  @ApiOperation({ summary: 'User login' })
-  @ApiResponse({ status: 200, description: 'User successfully logged in' })
+  @HttpCode(200)
+  @ApiOperation({ summary: 'User login — returns access + refresh token pair' })
+  @ApiResponse({ status: 200, type: AuthTokensResponseDto })
   @ApiResponse({ status: 401, description: 'Invalid credentials' })
   @ApiBody({ type: LoginDto })
-  async login(@Body() loginDto: LoginDto) {
+  async login(@Body() loginDto: LoginDto, @Req() req: Request) {
     const user = await this.authService.validateUser(
       loginDto.email,
       loginDto.password,
     );
-    if (!user) {
-      throw new UnauthorizedException('Invalid credentials');
-    }
-    return this.authService.login(user);
+    if (!user) throw new UnauthorizedException('Invalid credentials');
+    return this.authService.login(user, this.extractDeviceInfo(req));
+  }
+
+  @Post('refresh')
+  @HttpCode(200)
+  @ApiOperation({
+    summary: 'Rotate refresh token — returns new access + refresh token pair',
+  })
+  @ApiResponse({ status: 200, type: AuthTokensResponseDto })
+  @ApiResponse({
+    status: 401,
+    description:
+      'REFRESH_TOKEN_INVALID | REFRESH_TOKEN_REUSE_DETECTED | REFRESH_TOKEN_EXPIRED',
+  })
+  @ApiBody({ type: RefreshTokenDto })
+  async refresh(@Body() dto: RefreshTokenDto, @Req() req: Request) {
+    return this.authService.refresh(
+      dto.refreshToken,
+      this.extractDeviceInfo(req),
+    );
+  }
+
+  @Post('logout')
+  @HttpCode(200)
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth('JWT-auth')
+  @ApiOperation({
+    summary: 'Logout current session — revokes current refresh token',
+  })
+  @ApiResponse({ status: 200, description: 'Logged out successfully' })
+  @ApiBody({ type: RefreshTokenDto })
+  async logout(@Body() dto: RefreshTokenDto) {
+    await this.authService.logout(dto.refreshToken);
+    return { message: 'Logged out successfully' };
+  }
+
+  @Post('logout-all')
+  @HttpCode(200)
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth('JWT-auth')
+  @ApiOperation({
+    summary: 'Logout all sessions — revokes all refresh tokens for user',
+  })
+  @ApiResponse({ status: 200, description: 'All sessions revoked' })
+  async logoutAll(@Req() req: AuthenticatedRequest) {
+    await this.authService.logoutAll(req.user.userId);
+    return { message: 'All sessions revoked' };
+  }
+
+  @Get('sessions')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth('JWT-auth')
+  @ApiOperation({ summary: 'List active sessions for current user' })
+  @ApiResponse({ status: 200, type: [SessionResponseDto] })
+  async getSessions(@Req() req: AuthenticatedRequest) {
+    const sessions = await this.authService.getSessions(req.user.userId);
+    return sessions.map(
+      (s): SessionResponseDto => ({
+        id: s.id,
+        deviceId: s.deviceId,
+        userAgent: s.userAgent,
+        ipAddress: s.ipAddress,
+        createdAt: s.createdAt,
+        expiresAt: s.expiresAt,
+      }),
+    );
+  }
+
+  @Delete('sessions/:id')
+  @HttpCode(200)
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth('JWT-auth')
+  @ApiOperation({ summary: 'Revoke a specific session by ID' })
+  @ApiResponse({ status: 200, description: 'Session revoked' })
+  @ApiResponse({ status: 404, description: 'Session not found' })
+  async deleteSession(
+    @Param('id') sessionId: string,
+    @Req() req: AuthenticatedRequest,
+  ) {
+    const revoked = await this.authService.deleteSession(
+      sessionId,
+      req.user.userId,
+    );
+    if (!revoked) throw new NotFoundException('Session not found');
+    return { message: 'Session revoked' };
+  }
+
+  private extractDeviceInfo(req: Request) {
+    return {
+      userAgent: req.headers['user-agent'] ?? undefined,
+      ipAddress:
+        (req.headers['x-forwarded-for'] as string) ||
+        req.socket?.remoteAddress ||
+        undefined,
+      deviceId: (req.headers['x-device-id'] as string) ?? undefined,
+    };
   }
 }

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -41,7 +41,9 @@ export class AuthController {
   constructor(private readonly authService: AuthService) {}
 
   @Post('signup')
-  @ApiOperation({ summary: 'User signup — returns access + refresh token pair' })
+  @ApiOperation({
+    summary: 'User signup — returns access + refresh token pair',
+  })
   @ApiResponse({ status: 201, type: AuthTokensResponseDto })
   @ApiResponse({ status: 409, description: 'Email already exists' })
   @ApiBody({ type: SignupDto })

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -1,29 +1,37 @@
 import { Module } from '@nestjs/common';
 import { JwtModule } from '@nestjs/jwt';
 import { PassportModule } from '@nestjs/passport';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { AuthService } from './auth.service';
 import { AuthController } from './auth.controller';
 import { JwtStrategy } from './jwt.strategy';
+import { TokenService } from './token.service';
+import { RefreshToken } from './entities/refresh-token.entity';
 import { UsersModule } from '../users/users.module';
 import { ConfigModule, ConfigService } from '@nestjs/config';
+import { LoggerModule } from '../logger/logger.module';
 
 @Module({
   imports: [
     UsersModule,
     PassportModule,
+    LoggerModule,
+    TypeOrmModule.forFeature([RefreshToken]),
     JwtModule.registerAsync({
       imports: [ConfigModule],
       useFactory: (configService: ConfigService) => ({
-        secret: configService.get<string>('JWT_SECRET'),
-        signOptions: {
-          expiresIn: configService.get('JWT_EXPIRES_IN') ?? '1d',
-        },
+        // Default secret used by JwtService.sign() fallback; actual signing uses explicit secrets
+        secret:
+          configService.get<string>('JWT_ACCESS_SECRET') ??
+          configService.get<string>('JWT_SECRET') ??
+          'fallback-access-secret',
+        signOptions: { expiresIn: '15m' },
       }),
       inject: [ConfigService],
     }),
   ],
-  providers: [AuthService, JwtStrategy],
+  providers: [AuthService, TokenService, JwtStrategy],
   controllers: [AuthController],
-  exports: [AuthService],
+  exports: [AuthService, TokenService],
 })
 export class AuthModule {}

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,59 +1,100 @@
 import { Injectable, UnauthorizedException } from '@nestjs/common';
-import { JwtService } from '@nestjs/jwt';
 import { UsersService } from '../users/users.service';
-import { ConfigService } from '@nestjs/config';
 import { SignupDto } from './dto/signup.dto';
+import { TokenService, TokenPair } from './token.service';
+import { RefreshToken } from './entities/refresh-token.entity';
 import * as bcrypt from 'bcrypt';
+
+export interface AuthResponse extends TokenPair {
+  user: { id: number; name: string; email: string };
+  message?: string;
+}
+
+export interface AuthenticatedUser {
+  id: number;
+  name: string;
+  email: string;
+}
 
 @Injectable()
 export class AuthService {
   constructor(
-    private usersService: UsersService,
-    private jwtService: JwtService,
-    private configService: ConfigService,
+    private readonly usersService: UsersService,
+    private readonly tokenService: TokenService,
   ) {}
 
-  async validateUser(email: string, pass: string): Promise<any> {
+  async validateUser(
+    email: string,
+    pass: string,
+  ): Promise<AuthenticatedUser | null> {
     const user = await this.usersService.findByEmail(email);
     if (user && (await bcrypt.compare(pass, user.password))) {
-      const { password, ...result } = user;
-      return result;
+      return { id: user.id, name: user.name, email: user.email };
     }
     return null;
   }
 
-  async signup(signupDto: SignupDto) {
+  async signup(
+    signupDto: SignupDto,
+    opts: { deviceId?: string; userAgent?: string; ipAddress?: string } = {},
+  ): Promise<AuthResponse> {
     const userResponse = await this.usersService.createUser(signupDto);
-    // Get the actual user to create JWT payload
     const user = await this.usersService.findByEmail(signupDto.email);
+    if (!user) throw new UnauthorizedException('User creation failed');
 
-    if (!user) {
-      throw new UnauthorizedException('User creation failed');
-    }
-
-    const payload = { username: signupDto.email, sub: user.id };
+    const tokens = await this.tokenService.issueTokenPair(
+      user.id,
+      user.email,
+      opts,
+    );
     return {
-      access_token: this.jwtService.sign(payload),
-      expires_in: this.configService.get<string>('JWT_EXPIRES_IN'),
-      user: {
-        id: user.id,
-        name: user.name,
-        email: user.email,
-      },
+      ...tokens,
+      user: { id: user.id, name: user.name, email: user.email },
       message: userResponse.message,
     };
   }
 
-  async login(user: any) {
-    const payload = { username: user.email, sub: user.id };
+  async login(
+    user: AuthenticatedUser,
+    opts: { deviceId?: string; userAgent?: string; ipAddress?: string } = {},
+  ): Promise<AuthResponse> {
+    const tokens = await this.tokenService.issueTokenPair(
+      user.id,
+      user.email,
+      opts,
+    );
     return {
-      access_token: this.jwtService.sign(payload),
-      expires_in: this.configService.get<string>('JWT_EXPIRES_IN'),
-      user: {
-        id: user.id,
-        name: user.name,
-        email: user.email,
-      },
+      ...tokens,
+      user: { id: user.id, name: user.name, email: user.email },
     };
+  }
+
+  async refresh(
+    rawRefreshToken: string,
+    opts: { deviceId?: string; userAgent?: string; ipAddress?: string } = {},
+  ): Promise<TokenPair> {
+    return this.tokenService.rotateRefreshToken(rawRefreshToken, opts);
+  }
+
+  async logout(refreshToken: string): Promise<void> {
+    const payload = this.tokenService.decodeRefreshToken(refreshToken);
+    if (!payload) return;
+    await this.tokenService.revokeToken(payload.tokenId);
+  }
+
+  async logoutAll(userId: number): Promise<void> {
+    await this.tokenService.revokeAllUserTokens(userId);
+  }
+
+  async getSessions(userId: number): Promise<RefreshToken[]> {
+    return this.tokenService.getActiveSessions(userId);
+  }
+
+  async deleteSession(sessionId: string, userId: number): Promise<boolean> {
+    return this.tokenService.revokeSession(sessionId, userId);
+  }
+
+  async invalidateSessionsOnPasswordChange(userId: number): Promise<void> {
+    await this.tokenService.revokeAllUserTokens(userId);
   }
 }

--- a/src/auth/dto/auth-tokens-response.dto.ts
+++ b/src/auth/dto/auth-tokens-response.dto.ts
@@ -1,0 +1,18 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class AuthTokensResponseDto {
+  @ApiProperty()
+  accessToken: string;
+
+  @ApiProperty()
+  refreshToken: string;
+
+  @ApiProperty()
+  expiresIn: number;
+
+  @ApiProperty()
+  refreshExpiresIn: number;
+
+  @ApiProperty({ example: 'Bearer' })
+  tokenType: string;
+}

--- a/src/auth/dto/refresh-token.dto.ts
+++ b/src/auth/dto/refresh-token.dto.ts
@@ -1,0 +1,9 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class RefreshTokenDto {
+  @ApiProperty({ description: 'Valid refresh token' })
+  @IsString()
+  @IsNotEmpty()
+  refreshToken: string;
+}

--- a/src/auth/dto/session-response.dto.ts
+++ b/src/auth/dto/session-response.dto.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class SessionResponseDto {
+  @ApiProperty()
+  id: string;
+
+  @ApiProperty()
+  deviceId: string | null;
+
+  @ApiProperty()
+  userAgent: string | null;
+
+  @ApiProperty()
+  ipAddress: string | null;
+
+  @ApiProperty()
+  createdAt: Date;
+
+  @ApiProperty()
+  expiresAt: Date;
+}

--- a/src/auth/entities/refresh-token.entity.ts
+++ b/src/auth/entities/refresh-token.entity.ts
@@ -1,0 +1,54 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { User } from '../../users/user.entity';
+
+@Entity('refresh_tokens')
+@Index(['userId', 'isRevoked'])
+@Index(['familyId'])
+@Index(['jti'], { unique: true })
+export class RefreshToken {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'int' })
+  userId: number;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  user: User;
+
+  @Column({ type: 'varchar' })
+  tokenHash: string;
+
+  @Column({ type: 'uuid' })
+  familyId: string;
+
+  @Column({ type: 'uuid', unique: true })
+  jti: string;
+
+  @Column({ type: 'varchar', nullable: true })
+  deviceId: string | null;
+
+  @Column({ type: 'varchar', nullable: true })
+  userAgent: string | null;
+
+  @Column({ type: 'varchar', nullable: true })
+  ipAddress: string | null;
+
+  @Column({ type: 'boolean', default: false })
+  isRevoked: boolean;
+
+  @Column({ type: 'varchar', nullable: true })
+  replacedByTokenId: string | null;
+
+  @Column({ type: 'timestamp' })
+  expiresAt: Date;
+
+  @CreateDateColumn({ type: 'timestamp' })
+  createdAt: Date;
+}

--- a/src/auth/jwt.strategy.ts
+++ b/src/auth/jwt.strategy.ts
@@ -1,7 +1,13 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
 import { ConfigService } from '@nestjs/config';
+
+interface JwtAccessPayload {
+  sub: number;
+  email: string;
+  type?: string;
+}
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {
@@ -9,11 +15,24 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     super({
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
       ignoreExpiration: false,
-      secretOrKey: configService.get<string>('JWT_SECRET'),
+      secretOrKey:
+        configService.get<string>('JWT_ACCESS_SECRET') ??
+        configService.get<string>('JWT_SECRET') ??
+        'fallback-access-secret',
     });
   }
 
-  async validate(payload: any) {
-    return { userId: payload.sub, username: payload.username };
+  async validate(payload: JwtAccessPayload) {
+    if (payload.type !== 'access') {
+      throw new UnauthorizedException({
+        message: 'Refresh tokens cannot be used as access tokens',
+        code: 'ACCESS_TOKEN_INVALID',
+      });
+    }
+    return {
+      userId: payload.sub,
+      email: payload.email,
+      username: payload.email,
+    };
   }
 }

--- a/src/auth/token.service.spec.ts
+++ b/src/auth/token.service.spec.ts
@@ -1,0 +1,252 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { JwtService } from '@nestjs/jwt';
+import { ConfigService } from '@nestjs/config';
+import { UnauthorizedException } from '@nestjs/common';
+import { TokenService } from './token.service';
+import { RefreshToken } from './entities/refresh-token.entity';
+import { AppLogger } from '../logger/app-logger.service';
+import * as bcrypt from 'bcrypt';
+
+const mockRepo = () => ({
+  save: jest.fn(),
+  findOne: jest.fn(),
+  find: jest.fn(),
+  update: jest.fn(),
+});
+
+const mockJwtService = () => ({
+  sign: jest.fn(),
+  verify: jest.fn(),
+});
+
+const mockConfig = () => ({
+  get: jest.fn((key: string) => {
+    const map: Record<string, string> = {
+      JWT_ACCESS_SECRET: 'access-secret',
+      JWT_REFRESH_SECRET: 'refresh-secret',
+    };
+    return map[key];
+  }),
+});
+
+const mockLogger = () => ({
+  log: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+});
+
+describe('TokenService', () => {
+  let service: TokenService;
+  let repo: ReturnType<typeof mockRepo>;
+  let jwtService: ReturnType<typeof mockJwtService>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TokenService,
+        { provide: getRepositoryToken(RefreshToken), useFactory: mockRepo },
+        { provide: JwtService, useFactory: mockJwtService },
+        { provide: ConfigService, useFactory: mockConfig },
+        { provide: AppLogger, useFactory: mockLogger },
+      ],
+    }).compile();
+
+    service = module.get(TokenService);
+    repo = module.get(getRepositoryToken(RefreshToken));
+    jwtService = module.get(JwtService);
+  });
+
+  describe('issueTokenPair', () => {
+    it('returns a token pair with correct shape', async () => {
+      jwtService.sign.mockReturnValue('signed-token');
+      repo.save.mockResolvedValue({});
+
+      const result = await service.issueTokenPair(1, 'test@test.com');
+
+      expect(result.accessToken).toBe('signed-token');
+      expect(result.refreshToken).toBe('signed-token');
+      expect(result.tokenType).toBe('Bearer');
+      expect(result.expiresIn).toBe(900);
+      expect(result.refreshExpiresIn).toBe(604800);
+    });
+
+    it('stores a hashed refresh token — never plaintext', async () => {
+      jwtService.sign.mockReturnValue('raw-refresh');
+      repo.save.mockResolvedValue({});
+
+      await service.issueTokenPair(1, 'test@test.com');
+
+      const savedArg = repo.save.mock.calls[0][0];
+      expect(savedArg.tokenHash).toBeDefined();
+      expect(savedArg.tokenHash).not.toBe('raw-refresh');
+      const matches = await bcrypt.compare('raw-refresh', savedArg.tokenHash);
+      expect(matches).toBe(true);
+    });
+
+    it('accepts deviceId, userAgent, ipAddress', async () => {
+      jwtService.sign.mockReturnValue('t');
+      repo.save.mockResolvedValue({});
+
+      await service.issueTokenPair(1, 'a@b.com', {
+        deviceId: 'dev-1',
+        userAgent: 'Mozilla',
+        ipAddress: '1.2.3.4',
+      });
+
+      const saved = repo.save.mock.calls[0][0];
+      expect(saved.deviceId).toBe('dev-1');
+      expect(saved.userAgent).toBe('Mozilla');
+      expect(saved.ipAddress).toBe('1.2.3.4');
+    });
+  });
+
+  describe('rotateRefreshToken', () => {
+    it('throws REFRESH_TOKEN_INVALID for bad jwt', async () => {
+      jwtService.verify.mockImplementation(() => {
+        throw new Error('invalid');
+      });
+
+      await expect(service.rotateRefreshToken('bad')).rejects.toThrow(
+        UnauthorizedException,
+      );
+    });
+
+    it('throws REFRESH_TOKEN_EXPIRED for expired jwt', async () => {
+      jwtService.verify.mockImplementation(() => {
+        const error = new Error('expired');
+        error.name = 'TokenExpiredError';
+        throw error;
+      });
+
+      await expect(service.rotateRefreshToken('expired')).rejects.toMatchObject({
+        response: expect.objectContaining({ code: 'REFRESH_TOKEN_EXPIRED' }),
+      });
+    });
+
+    it('throws REFRESH_TOKEN_INVALID for wrong token type', async () => {
+      jwtService.verify.mockReturnValue({
+        sub: 1,
+        email: 'a@b.com',
+        jti: 'jti',
+        type: 'access',
+        familyId: 'fam',
+        tokenId: 'tid',
+      });
+
+      await expect(service.rotateRefreshToken('tok')).rejects.toMatchObject({
+        response: expect.objectContaining({ code: 'REFRESH_TOKEN_INVALID' }),
+      });
+    });
+
+    it('throws REFRESH_TOKEN_INVALID when stored record not found', async () => {
+      jwtService.verify.mockReturnValue({
+        sub: 1,
+        email: 'a@b.com',
+        jti: 'jti',
+        type: 'refresh',
+        familyId: 'fam',
+        tokenId: 'tid',
+      });
+      repo.findOne.mockResolvedValue(null);
+
+      await expect(service.rotateRefreshToken('tok')).rejects.toMatchObject({
+        response: expect.objectContaining({ code: 'REFRESH_TOKEN_INVALID' }),
+      });
+    });
+
+    it('throws REFRESH_TOKEN_REUSE_DETECTED and revokes family when token is already revoked', async () => {
+      jwtService.verify.mockReturnValue({
+        sub: 1,
+        email: 'a@b.com',
+        jti: 'jti',
+        type: 'refresh',
+        familyId: 'fam-1',
+        tokenId: 'tid-1',
+      });
+      repo.findOne.mockResolvedValue({
+        id: 'tid-1',
+        userId: 1,
+        jti: 'jti',
+        familyId: 'fam-1',
+        isRevoked: true,
+      });
+      repo.update.mockResolvedValue({});
+
+      await expect(service.rotateRefreshToken('tok')).rejects.toMatchObject({
+        response: expect.objectContaining({
+          code: 'REFRESH_TOKEN_REUSE_DETECTED',
+        }),
+      });
+
+      expect(repo.update).toHaveBeenCalledWith(
+        { familyId: 'fam-1', isRevoked: false },
+        { isRevoked: true },
+      );
+    });
+
+    it('throws REFRESH_TOKEN_EXPIRED for expired stored token rows', async () => {
+      jwtService.verify.mockReturnValue({
+        sub: 1,
+        email: 'a@b.com',
+        jti: 'jti',
+        type: 'refresh',
+        familyId: 'fam-1',
+        tokenId: 'tid-1',
+      });
+      repo.findOne.mockResolvedValue({
+        id: 'tid-1',
+        userId: 1,
+        jti: 'jti',
+        familyId: 'fam-1',
+        isRevoked: false,
+        expiresAt: new Date(Date.now() - 1000),
+      });
+      repo.update.mockResolvedValue({});
+
+      await expect(service.rotateRefreshToken('tok')).rejects.toMatchObject({
+        response: expect.objectContaining({ code: 'REFRESH_TOKEN_EXPIRED' }),
+      });
+      expect(repo.update).toHaveBeenCalledWith('tid-1', { isRevoked: true });
+    });
+  });
+
+  describe('revokeAllUserTokens', () => {
+    it('revokes all active tokens for a user', async () => {
+      repo.update.mockResolvedValue({});
+      await service.revokeAllUserTokens(42);
+      expect(repo.update).toHaveBeenCalledWith(
+        { userId: 42, isRevoked: false },
+        { isRevoked: true },
+      );
+    });
+  });
+
+  describe('getActiveSessions', () => {
+    it('returns non-revoked sessions for user', async () => {
+      const sessions = [{ id: 's1' }, { id: 's2' }];
+      repo.find.mockResolvedValue(sessions);
+      const result = await service.getActiveSessions(1);
+      expect(result).toEqual(sessions);
+      expect(repo.find).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { userId: 1, isRevoked: false } }),
+      );
+    });
+  });
+
+  describe('revokeSession', () => {
+    it('returns false when session not found', async () => {
+      repo.findOne.mockResolvedValue(null);
+      const result = await service.revokeSession('sid', 1);
+      expect(result).toBe(false);
+    });
+
+    it('returns true and revokes when session belongs to user', async () => {
+      repo.findOne.mockResolvedValue({ id: 'sid', userId: 1 });
+      repo.update.mockResolvedValue({});
+      const result = await service.revokeSession('sid', 1);
+      expect(result).toBe(true);
+      expect(repo.update).toHaveBeenCalledWith('sid', { isRevoked: true });
+    });
+  });
+});

--- a/src/auth/token.service.spec.ts
+++ b/src/auth/token.service.spec.ts
@@ -119,9 +119,11 @@ describe('TokenService', () => {
         throw error;
       });
 
-      await expect(service.rotateRefreshToken('expired')).rejects.toMatchObject({
-        response: expect.objectContaining({ code: 'REFRESH_TOKEN_EXPIRED' }),
-      });
+      await expect(service.rotateRefreshToken('expired')).rejects.toMatchObject(
+        {
+          response: expect.objectContaining({ code: 'REFRESH_TOKEN_EXPIRED' }),
+        },
+      );
     });
 
     it('throws REFRESH_TOKEN_INVALID for wrong token type', async () => {
@@ -229,7 +231,13 @@ describe('TokenService', () => {
       const result = await service.getActiveSessions(1);
       expect(result).toEqual(sessions);
       expect(repo.find).toHaveBeenCalledWith(
-        expect.objectContaining({ where: { userId: 1, isRevoked: false } }),
+        expect.objectContaining({
+          where: {
+            userId: 1,
+            isRevoked: false,
+            expiresAt: expect.any(Object),
+          },
+        }),
       );
     });
   });

--- a/src/auth/token.service.ts
+++ b/src/auth/token.service.ts
@@ -1,0 +1,305 @@
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { InjectRepository } from '@nestjs/typeorm';
+import { MoreThan, Repository } from 'typeorm';
+import { ConfigService } from '@nestjs/config';
+import { v4 as uuidv4 } from 'uuid';
+import * as bcrypt from 'bcrypt';
+import { RefreshToken } from './entities/refresh-token.entity';
+import { AppLogger } from '../logger/app-logger.service';
+
+export interface TokenPair {
+  accessToken: string;
+  refreshToken: string;
+  expiresIn: number;
+  refreshExpiresIn: number;
+  tokenType: string;
+}
+
+export interface RefreshPayload {
+  sub: number;
+  email: string;
+  jti: string;
+  type: 'refresh';
+  familyId: string;
+  tokenId: string;
+}
+
+export interface AccessPayload {
+  sub: number;
+  email: string;
+  jti: string;
+  type: 'access';
+}
+
+type DeviceInfo = {
+  deviceId?: string;
+  userAgent?: string;
+  ipAddress?: string;
+};
+
+@Injectable()
+export class TokenService {
+  private readonly ACCESS_EXPIRES_SECONDS = 15 * 60; // 15 min
+  private readonly REFRESH_EXPIRES_SECONDS = 7 * 24 * 60 * 60; // 7 days
+
+  constructor(
+    @InjectRepository(RefreshToken)
+    private readonly refreshTokenRepo: Repository<RefreshToken>,
+    private readonly jwtService: JwtService,
+    private readonly configService: ConfigService,
+    private readonly logger: AppLogger,
+  ) {}
+
+  async issueTokenPair(
+    userId: number,
+    email: string,
+    opts: DeviceInfo & { familyId?: string } = {},
+  ): Promise<TokenPair> {
+    const tokenPair = await this.createTokenPair(
+      userId,
+      email,
+      opts,
+    );
+    return this.toPublicTokenPair(tokenPair);
+  }
+
+  private async createTokenPair(
+    userId: number,
+    email: string,
+    opts: DeviceInfo & { familyId?: string } = {},
+  ): Promise<TokenPair & { tokenId: string }> {
+    const jti = uuidv4();
+    const familyId = opts.familyId ?? uuidv4();
+    const tokenId = uuidv4();
+
+    const accessPayload = {
+      sub: userId,
+      email,
+      jti: uuidv4(),
+      type: 'access' as const,
+    };
+    const refreshPayload: Omit<RefreshPayload, 'iat' | 'exp'> = {
+      sub: userId,
+      email,
+      jti,
+      type: 'refresh' as const,
+      familyId,
+      tokenId,
+    };
+
+    const accessSecret = this.getAccessSecret();
+    const refreshSecret = this.getRefreshSecret();
+
+    const accessToken = this.jwtService.sign(accessPayload, {
+      secret: accessSecret,
+      expiresIn: this.ACCESS_EXPIRES_SECONDS,
+    });
+
+    const rawRefreshToken = this.jwtService.sign(refreshPayload, {
+      secret: refreshSecret,
+      expiresIn: this.REFRESH_EXPIRES_SECONDS,
+    });
+
+    const tokenHash = await bcrypt.hash(rawRefreshToken, 10);
+    const expiresAt = new Date(
+      Date.now() + this.REFRESH_EXPIRES_SECONDS * 1000,
+    );
+
+    await this.refreshTokenRepo.save({
+      id: tokenId,
+      userId,
+      tokenHash,
+      familyId,
+      jti,
+      deviceId: opts.deviceId ?? null,
+      userAgent: opts.userAgent ?? null,
+      ipAddress: opts.ipAddress ?? null,
+      isRevoked: false,
+      replacedByTokenId: null,
+      expiresAt,
+    });
+
+    this.logger.log(
+      `Issued token pair for userId=${userId} jti=${jti}`,
+      TokenService.name,
+    );
+
+    return {
+      accessToken,
+      refreshToken: rawRefreshToken,
+      expiresIn: this.ACCESS_EXPIRES_SECONDS,
+      refreshExpiresIn: this.REFRESH_EXPIRES_SECONDS,
+      tokenType: 'Bearer',
+      tokenId,
+    };
+  }
+
+  async rotateRefreshToken(
+    rawRefreshToken: string,
+    opts: DeviceInfo = {},
+  ): Promise<TokenPair> {
+    const refreshSecret = this.getRefreshSecret();
+
+    let payload: RefreshPayload;
+    try {
+      payload = this.jwtService.verify<RefreshPayload>(rawRefreshToken, {
+        secret: refreshSecret,
+      });
+    } catch (error) {
+      if ((error as Error).name === 'TokenExpiredError') {
+        throw new UnauthorizedException({
+          message: 'Refresh token expired',
+          code: 'REFRESH_TOKEN_EXPIRED',
+        });
+      }
+      throw new UnauthorizedException({
+        message: 'Invalid or expired refresh token',
+        code: 'REFRESH_TOKEN_INVALID',
+      });
+    }
+
+    if (payload.type !== 'refresh') {
+      throw new UnauthorizedException({
+        message: 'Invalid token type',
+        code: 'REFRESH_TOKEN_INVALID',
+      });
+    }
+
+    const stored = await this.refreshTokenRepo.findOne({
+      where: { id: payload.tokenId },
+    });
+
+    if (
+      !stored ||
+      stored.userId !== payload.sub ||
+      stored.jti !== payload.jti ||
+      stored.familyId !== payload.familyId
+    ) {
+      throw new UnauthorizedException({
+        message: 'Refresh token not found',
+        code: 'REFRESH_TOKEN_INVALID',
+      });
+    }
+
+    // Reuse detection: token already revoked → revoke entire family
+    if (stored.isRevoked) {
+      this.logger.warn(
+        `Refresh token reuse detected for familyId=${payload.familyId} userId=${payload.sub}`,
+        TokenService.name,
+      );
+      await this.revokeFamilyTokens(payload.familyId);
+      throw new UnauthorizedException({
+        message: 'Refresh token reuse detected',
+        code: 'REFRESH_TOKEN_REUSE_DETECTED',
+      });
+    }
+
+    if (stored.expiresAt.getTime() <= Date.now()) {
+      await this.revokeToken(stored.id);
+      throw new UnauthorizedException({
+        message: 'Refresh token expired',
+        code: 'REFRESH_TOKEN_EXPIRED',
+      });
+    }
+
+    const valid = await bcrypt.compare(rawRefreshToken, stored.tokenHash);
+    if (!valid) {
+      throw new UnauthorizedException({
+        message: 'Invalid refresh token',
+        code: 'REFRESH_TOKEN_INVALID',
+      });
+    }
+
+    const newPair = await this.createTokenPair(payload.sub, payload.email, {
+      familyId: payload.familyId,
+      deviceId: opts.deviceId ?? stored.deviceId ?? undefined,
+      userAgent: opts.userAgent ?? stored.userAgent ?? undefined,
+      ipAddress: opts.ipAddress ?? stored.ipAddress ?? undefined,
+    });
+
+    await this.refreshTokenRepo.update(stored.id, {
+      isRevoked: true,
+      replacedByTokenId: newPair.tokenId,
+    });
+
+    return this.toPublicTokenPair(newPair);
+  }
+
+  async revokeToken(tokenId: string): Promise<void> {
+    await this.refreshTokenRepo.update(tokenId, { isRevoked: true });
+  }
+
+  async revokeAllUserTokens(userId: number): Promise<void> {
+    await this.refreshTokenRepo.update(
+      { userId, isRevoked: false },
+      { isRevoked: true },
+    );
+  }
+
+  private async revokeFamilyTokens(familyId: string): Promise<void> {
+    await this.refreshTokenRepo.update(
+      { familyId, isRevoked: false },
+      { isRevoked: true },
+    );
+  }
+
+  verifyAccessToken(token: string): AccessPayload {
+    const secret = this.getAccessSecret();
+    return this.jwtService.verify<AccessPayload>(token, { secret });
+  }
+
+  decodeRefreshToken(raw: string): RefreshPayload | null {
+    try {
+      const refreshSecret = this.getRefreshSecret();
+      return this.jwtService.verify<RefreshPayload>(raw, {
+        secret: refreshSecret,
+      });
+    } catch {
+      return null;
+    }
+  }
+
+  async getActiveSessions(userId: number): Promise<RefreshToken[]> {
+    return this.refreshTokenRepo.find({
+      where: { userId, isRevoked: false, expiresAt: MoreThan(new Date()) },
+      order: { createdAt: 'DESC' },
+    });
+  }
+
+  async revokeSession(sessionId: string, userId: number): Promise<boolean> {
+    const session = await this.refreshTokenRepo.findOne({
+      where: { id: sessionId, userId },
+    });
+    if (!session) return false;
+    await this.refreshTokenRepo.update(sessionId, { isRevoked: true });
+    return true;
+  }
+
+  private getAccessSecret(): string {
+    return (
+      this.configService.get<string>('JWT_ACCESS_SECRET') ??
+      this.configService.get<string>('JWT_SECRET') ??
+      'fallback-access-secret'
+    );
+  }
+
+  private getRefreshSecret(): string {
+    return (
+      this.configService.get<string>('JWT_REFRESH_SECRET') ??
+      'fallback-refresh-secret'
+    );
+  }
+
+  private toPublicTokenPair(
+    tokenPair: TokenPair & { tokenId: string },
+  ): TokenPair {
+    return {
+      accessToken: tokenPair.accessToken,
+      refreshToken: tokenPair.refreshToken,
+      expiresIn: tokenPair.expiresIn,
+      refreshExpiresIn: tokenPair.refreshExpiresIn,
+      tokenType: tokenPair.tokenType,
+    };
+  }
+}

--- a/src/auth/token.service.ts
+++ b/src/auth/token.service.ts
@@ -3,7 +3,7 @@ import { JwtService } from '@nestjs/jwt';
 import { InjectRepository } from '@nestjs/typeorm';
 import { MoreThan, Repository } from 'typeorm';
 import { ConfigService } from '@nestjs/config';
-import { v4 as uuidv4 } from 'uuid';
+import { randomUUID } from 'node:crypto';
 import * as bcrypt from 'bcrypt';
 import { RefreshToken } from './entities/refresh-token.entity';
 import { AppLogger } from '../logger/app-logger.service';
@@ -56,11 +56,7 @@ export class TokenService {
     email: string,
     opts: DeviceInfo & { familyId?: string } = {},
   ): Promise<TokenPair> {
-    const tokenPair = await this.createTokenPair(
-      userId,
-      email,
-      opts,
-    );
+    const tokenPair = await this.createTokenPair(userId, email, opts);
     return this.toPublicTokenPair(tokenPair);
   }
 
@@ -69,14 +65,14 @@ export class TokenService {
     email: string,
     opts: DeviceInfo & { familyId?: string } = {},
   ): Promise<TokenPair & { tokenId: string }> {
-    const jti = uuidv4();
-    const familyId = opts.familyId ?? uuidv4();
-    const tokenId = uuidv4();
+    const jti = randomUUID();
+    const familyId = opts.familyId ?? randomUUID();
+    const tokenId = randomUUID();
 
     const accessPayload = {
       sub: userId,
       email,
-      jti: uuidv4(),
+      jti: randomUUID(),
       type: 'access' as const,
     };
     const refreshPayload: Omit<RefreshPayload, 'iat' | 'exp'> = {

--- a/src/exception/globalException.filter.ts
+++ b/src/exception/globalException.filter.ts
@@ -19,7 +19,8 @@ export class GlobalExceptionFilter implements ExceptionFilter {
     const status =
       exception instanceof HttpException ? exception.getStatus() : 500;
 
-    let message: string | string[] = 'An error occurred | internal server error';
+    let message: string | string[] =
+      'An error occurred | internal server error';
     let error =
       exception instanceof HttpException
         ? exception.name

--- a/src/exception/globalException.filter.ts
+++ b/src/exception/globalException.filter.ts
@@ -3,43 +3,47 @@ import {
   Catch,
   ExceptionFilter,
   HttpException,
-  Logger,
 } from '@nestjs/common';
-import { Response } from 'express';
+import { Request, Response } from 'express';
 import { AppLogger } from '../logger/app-logger.service';
 
 @Catch()
 export class GlobalExceptionFilter implements ExceptionFilter {
   private readonly logger = new AppLogger();
+
   catch(exception: unknown, host: ArgumentsHost): void {
     const caughtException = host.switchToHttp();
-
-    // response and request objects
-    // instance of the response to send out the error
     const response = caughtException.getResponse<Response>();
-
-    // instance of the request to get the request details
     const request = caughtException.getRequest<Request>();
 
-    // get the appropriate status code of the the exception thrown e.g 400, 404
-    // or 500 if it internal error
     const status =
       exception instanceof HttpException ? exception.getStatus() : 500;
-    // get the message thrown from the exception object
-    const message =
-      exception instanceof HttpException
-        ? exception.message
-        : 'An error occurred | internal server error';
 
-    const error =
+    let message: string | string[] = 'An error occurred | internal server error';
+    let error =
       exception instanceof HttpException
         ? exception.name
         : ((exception as Error)?.name ?? 'UnknownError');
+    let code: string | undefined;
+
+    if (exception instanceof HttpException) {
+      const exResponse = exception.getResponse();
+      if (typeof exResponse === 'object' && exResponse !== null) {
+        const responseBody = exResponse as Record<string, unknown>;
+        message =
+          (responseBody.message as string | string[] | undefined) ??
+          exception.message;
+        error = (responseBody.error as string | undefined) ?? error;
+        code = responseBody.code as string | undefined;
+      } else if (typeof exResponse === 'string') {
+        message = exResponse;
+      } else {
+        message = exception.message;
+      }
+    }
 
     const errorMessage =
-      typeof message === 'string'
-        ? message
-        : (message as any)?.message || 'Unexpected error';
+      typeof message === 'string' ? message : message.join(', ');
 
     this.logger.error(
       `[${request.method}] ${request.url} ${status} - ${errorMessage}`,
@@ -47,13 +51,15 @@ export class GlobalExceptionFilter implements ExceptionFilter {
       GlobalExceptionFilter.name,
     );
 
-    // a json response to send out showing the full error details
-    response.status(status).json({
+    const body: Record<string, unknown> = {
       statusCode: status,
-      message: message,
+      message,
       timestamp: new Date().toISOString(),
       path: request.url,
-      error: error,
-    });
+      error,
+    };
+    if (code) body.code = code;
+
+    response.status(status).json(body);
   }
 }

--- a/src/migrations/1769035200000-CreateRefreshTokens.ts
+++ b/src/migrations/1769035200000-CreateRefreshTokens.ts
@@ -1,0 +1,114 @@
+import {
+  MigrationInterface,
+  QueryRunner,
+  Table,
+  TableForeignKey,
+  TableIndex,
+} from 'typeorm';
+
+export class CreateRefreshTokens1769035200000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'refresh_tokens',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            generationStrategy: 'uuid',
+            isGenerated: true,
+          },
+          {
+            name: 'userId',
+            type: 'int',
+          },
+          {
+            name: 'tokenHash',
+            type: 'varchar',
+          },
+          {
+            name: 'familyId',
+            type: 'uuid',
+          },
+          {
+            name: 'jti',
+            type: 'uuid',
+            isUnique: true,
+          },
+          {
+            name: 'deviceId',
+            type: 'varchar',
+            isNullable: true,
+          },
+          {
+            name: 'userAgent',
+            type: 'varchar',
+            isNullable: true,
+          },
+          {
+            name: 'ipAddress',
+            type: 'varchar',
+            isNullable: true,
+          },
+          {
+            name: 'isRevoked',
+            type: 'boolean',
+            default: false,
+          },
+          {
+            name: 'replacedByTokenId',
+            type: 'varchar',
+            isNullable: true,
+          },
+          {
+            name: 'expiresAt',
+            type: 'timestamp',
+          },
+          {
+            name: 'createdAt',
+            type: 'timestamp',
+            default: 'CURRENT_TIMESTAMP',
+          },
+        ],
+      }),
+    );
+
+    await queryRunner.createForeignKey(
+      'refresh_tokens',
+      new TableForeignKey({
+        columnNames: ['userId'],
+        referencedTableName: 'users',
+        referencedColumnNames: ['id'],
+        onDelete: 'CASCADE',
+      }),
+    );
+
+    await queryRunner.createIndex(
+      'refresh_tokens',
+      new TableIndex({
+        name: 'IDX_REFRESH_TOKENS_USER_REVOKED',
+        columnNames: ['userId', 'isRevoked'],
+      }),
+    );
+    await queryRunner.createIndex(
+      'refresh_tokens',
+      new TableIndex({
+        name: 'IDX_REFRESH_TOKENS_FAMILY',
+        columnNames: ['familyId'],
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropIndex(
+      'refresh_tokens',
+      'IDX_REFRESH_TOKENS_FAMILY',
+    );
+    await queryRunner.dropIndex(
+      'refresh_tokens',
+      'IDX_REFRESH_TOKENS_USER_REVOKED',
+    );
+    await queryRunner.dropTable('refresh_tokens');
+  }
+}

--- a/src/migrations/1769035200000-CreateRefreshTokens.ts
+++ b/src/migrations/1769035200000-CreateRefreshTokens.ts
@@ -101,10 +101,7 @@ export class CreateRefreshTokens1769035200000 implements MigrationInterface {
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.dropIndex(
-      'refresh_tokens',
-      'IDX_REFRESH_TOKENS_FAMILY',
-    );
+    await queryRunner.dropIndex('refresh_tokens', 'IDX_REFRESH_TOKENS_FAMILY');
     await queryRunner.dropIndex(
       'refresh_tokens',
       'IDX_REFRESH_TOKENS_USER_REVOKED',

--- a/src/migrations/appDataSource.db.ts
+++ b/src/migrations/appDataSource.db.ts
@@ -1,11 +1,7 @@
 import { ConfigService } from '@nestjs/config';
 import { User } from 'src/users/user.entity';
-import { DataSource, DataSourceOptions } from 'typeorm';
-
-// import { config } from "dotenv";
-// config({ path: '.env' })
-
-// const configService = new ConfigService();
+import { RefreshToken } from 'src/auth/entities/refresh-token.entity';
+import { DataSourceOptions } from 'typeorm';
 
 export function dataOption(configService: ConfigService): DataSourceOptions {
   return {
@@ -15,11 +11,7 @@ export function dataOption(configService: ConfigService): DataSourceOptions {
     username: configService.get<string>('DB_USERNAME'),
     password: configService.get<string>('DB_PASSWORD'),
     database: configService.get<string>('DB_NAME'),
-    entities: [User],
+    entities: [User, RefreshToken],
     synchronize: true,
-    // migrations: ['dis/migrations/*.ts'],
-    // migrationsRun: true,
   };
 }
-
-// export const appDataSource = new DataSource(dataOption);

--- a/src/users/dtos/updateUser.dto.ts
+++ b/src/users/dtos/updateUser.dto.ts
@@ -1,5 +1,20 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsEmail, IsOptional, IsString, MinLength } from 'class-validator';
+
 export class UpdateUserDto {
+  @ApiPropertyOptional()
+  @IsString()
+  @IsOptional()
   name?: string;
+
+  @ApiPropertyOptional()
+  @IsEmail()
+  @IsOptional()
   email?: string;
+
+  @ApiPropertyOptional({ minLength: 6 })
+  @IsString()
+  @MinLength(6)
+  @IsOptional()
   password?: string;
 }

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -16,6 +16,7 @@ import { CreateUserDto } from './dtos/createUser.dto';
 import { UserResponseDto } from './dtos/userResponse.dto';
 import { GetUsersQueryDto } from './dtos/get-users-query.dto';
 import { PaginatedResponseDto } from './dtos/paginated-response.dto';
+import { UpdateUserDto } from './dtos/updateUser.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import {
   ApiTags,
@@ -230,7 +231,7 @@ export class UsersController {
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   async updateUser(
     @Param('id') id: number,
-    @Body() updateUserDto: CreateUserDto,
+    @Body() updateUserDto: UpdateUserDto,
   ): Promise<UserResponseDto> {
     return this.usersService.updateUser(id, updateUserDto);
   }

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -4,12 +4,16 @@ import { UsersController } from './users.controller';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { CacheModule } from '@nestjs/cache-manager';
 import { User } from './user.entity';
+import { RefreshToken } from '../auth/entities/refresh-token.entity';
 import { UsersQueryService } from './services/users-query.service';
 import { SearchService } from './services/search.service';
 import { PermissionService } from './services/permission.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([User]), CacheModule.register()],
+  imports: [
+    TypeOrmModule.forFeature([User, RefreshToken]),
+    CacheModule.register(),
+  ],
   providers: [
     UsersService,
     UsersQueryService,

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -6,6 +6,7 @@ import {
 } from '@nestjs/common';
 import { Repository } from 'typeorm';
 import { User } from './user.entity';
+import { RefreshToken } from '../auth/entities/refresh-token.entity';
 import { InjectRepository } from '@nestjs/typeorm';
 import { CreateUserDto } from './dtos/createUser.dto';
 import { UserResponseDto } from './dtos/userResponse.dto';
@@ -28,6 +29,8 @@ export class UsersService {
   constructor(
     @InjectRepository(User)
     private readonly userRepository: Repository<User>,
+    @InjectRepository(RefreshToken)
+    private readonly refreshTokenRepository: Repository<RefreshToken>,
     private readonly queryService: UsersQueryService,
     private readonly searchService: SearchService,
     private readonly permissionService: PermissionService,
@@ -156,8 +159,22 @@ export class UsersService {
       throw new NotFoundException('user not found');
     }
 
-    Object.assign(user, updateUserDto);
+    const updatePayload = { ...updateUserDto };
+    let passwordChanged = false;
+    if (typeof updatePayload.password === 'string') {
+      updatePayload.password = await bcrypt.hash(updatePayload.password, 10);
+      passwordChanged = true;
+    }
+
+    Object.assign(user, updatePayload);
     let savedUser: User = await this.userRepository.save(user);
+
+    if (passwordChanged) {
+      await this.refreshTokenRepository.update(
+        { userId: id, isRevoked: false },
+        { isRevoked: true },
+      );
+    }
 
     // Update search text and invalidate caches
     await this.searchService.updateSearchTextForUser(savedUser.id);

--- a/test/auth.e2e-spec.ts
+++ b/test/auth.e2e-spec.ts
@@ -306,11 +306,10 @@ describe('Auth E2E', () => {
       const second = await signupUser(testApp.app, {
         email: 'second-session@example.com',
       });
-      const secondSession = await testApp.refreshTokenRepository.findOneByOrFail(
-        {
+      const secondSession =
+        await testApp.refreshTokenRepository.findOneByOrFail({
           userId: second.user.id,
-        },
-      );
+        });
 
       await request(testApp.app.getHttpServer())
         .delete(`/auth/sessions/${secondSession.id}`)

--- a/test/auth.e2e-spec.ts
+++ b/test/auth.e2e-spec.ts
@@ -1,6 +1,8 @@
+import * as bcrypt from 'bcrypt';
 import * as request from 'supertest';
 import { clearDatabase, createE2eApp, E2eTestApp } from './helpers/e2e-app';
 import {
+  bearerToken,
   buildSignupPayload,
   loginUser,
   signupUser,
@@ -23,7 +25,7 @@ describe('Auth E2E', () => {
   });
 
   describe('POST /auth/signup', () => {
-    it('creates a user and returns a token without exposing the password', async () => {
+    it('creates a user and returns an access and refresh token pair', async () => {
       const payload = buildSignupPayload({
         name: 'Signup User',
         email: 'signup@example.com',
@@ -31,18 +33,49 @@ describe('Auth E2E', () => {
 
       const response = await request(testApp.app.getHttpServer())
         .post('/auth/signup')
+        .set('User-Agent', 'signup-agent')
+        .set('X-Device-Id', 'signup-device')
         .send(payload)
         .expect(201);
 
-      expect(response.body.access_token).toEqual(expect.any(String));
-      expect(response.body.expires_in).toBe('1h');
-      expect(response.body.message).toBe('user created successfully...');
+      expect(response.body).toMatchObject({
+        accessToken: expect.any(String),
+        refreshToken: expect.any(String),
+        expiresIn: 900,
+        refreshExpiresIn: 604800,
+        tokenType: 'Bearer',
+        message: 'user created successfully...',
+      });
       expect(response.body.user).toMatchObject({
         id: 1,
         name: payload.name,
         email: payload.email,
       });
       expect(response.body.user).not.toHaveProperty('password');
+    });
+
+    it('stores refresh tokens hashed and tracks device metadata', async () => {
+      const response = await request(testApp.app.getHttpServer())
+        .post('/auth/signup')
+        .set('User-Agent', 'hashed-agent')
+        .set('X-Device-Id', 'hashed-device')
+        .send(buildSignupPayload({ email: 'hashed@example.com' }))
+        .expect(201);
+
+      const tokens = await testApp.refreshTokenRepository.find();
+
+      expect(tokens).toHaveLength(1);
+      expect(tokens[0].tokenHash).not.toBe(response.body.refreshToken);
+      const hashMatches = await bcrypt.compare(
+        response.body.refreshToken,
+        tokens[0].tokenHash,
+      );
+      expect(hashMatches).toBe(true);
+      expect(tokens[0]).toMatchObject({
+        deviceId: 'hashed-device',
+        userAgent: 'hashed-agent',
+        isRevoked: false,
+      });
     });
 
     it('rejects duplicate email signup', async () => {
@@ -65,7 +98,7 @@ describe('Auth E2E', () => {
   });
 
   describe('POST /auth/login', () => {
-    it('logs in an existing user and returns a bearer token payload', async () => {
+    it('logs in an existing user and returns a bearer token pair', async () => {
       const { payload, user: signupUserResponse } = await signupUser(
         testApp.app,
         {
@@ -74,13 +107,14 @@ describe('Auth E2E', () => {
         },
       );
 
-      const { token, user } = await loginUser(
+      const { token, refreshToken, user } = await loginUser(
         testApp.app,
         payload.email,
         TEST_PASSWORD,
       );
 
       expect(token).toEqual(expect.any(String));
+      expect(refreshToken).toEqual(expect.any(String));
       expect(user).toEqual(signupUserResponse);
       expect(user.email).toBe(payload.email);
     });
@@ -96,6 +130,234 @@ describe('Auth E2E', () => {
         .expect(401);
 
       expect(response.body.message).toBe('Invalid credentials');
+    });
+  });
+
+  describe('refresh token rotation', () => {
+    it('rotates a refresh token pair and immediately revokes the old token', async () => {
+      const { refreshToken } = await signupUser(testApp.app, {
+        email: 'rotate@example.com',
+      });
+
+      const response = await request(testApp.app.getHttpServer())
+        .post('/auth/refresh')
+        .send({ refreshToken })
+        .expect(200);
+
+      expect(response.body).toMatchObject({
+        accessToken: expect.any(String),
+        refreshToken: expect.any(String),
+        expiresIn: 900,
+        refreshExpiresIn: 604800,
+        tokenType: 'Bearer',
+      });
+      expect(response.body.refreshToken).not.toBe(refreshToken);
+
+      const tokens = await testApp.refreshTokenRepository.find({
+        order: { createdAt: 'ASC' },
+      });
+      expect(tokens).toHaveLength(2);
+      expect(tokens[0].isRevoked).toBe(true);
+      expect(tokens[0].replacedByTokenId).toBe(tokens[1].id);
+      expect(tokens[1].isRevoked).toBe(false);
+      expect(tokens[1].familyId).toBe(tokens[0].familyId);
+    });
+
+    it('detects refresh token reuse and revokes the full token family', async () => {
+      const { refreshToken } = await signupUser(testApp.app, {
+        email: 'reuse@example.com',
+      });
+
+      const rotated = await request(testApp.app.getHttpServer())
+        .post('/auth/refresh')
+        .send({ refreshToken })
+        .expect(200);
+
+      const response = await request(testApp.app.getHttpServer())
+        .post('/auth/refresh')
+        .send({ refreshToken })
+        .expect(401);
+
+      expect(response.body.code).toBe('REFRESH_TOKEN_REUSE_DETECTED');
+
+      await request(testApp.app.getHttpServer())
+        .post('/auth/refresh')
+        .send({ refreshToken: rotated.body.refreshToken })
+        .expect(401);
+
+      const tokens = await testApp.refreshTokenRepository.find();
+      expect(tokens.every((token) => token.isRevoked)).toBe(true);
+    });
+
+    it('returns REFRESH_TOKEN_INVALID for malformed refresh tokens', async () => {
+      const response = await request(testApp.app.getHttpServer())
+        .post('/auth/refresh')
+        .send({ refreshToken: 'not-a-jwt' })
+        .expect(401);
+
+      expect(response.body).toMatchObject({
+        statusCode: 401,
+        code: 'REFRESH_TOKEN_INVALID',
+      });
+    });
+
+    it('returns REFRESH_TOKEN_EXPIRED for expired persisted sessions', async () => {
+      const { refreshToken } = await signupUser(testApp.app, {
+        email: 'expired@example.com',
+      });
+      const stored = await testApp.refreshTokenRepository.findOneByOrFail({
+        isRevoked: false,
+      });
+      stored.expiresAt = new Date(Date.now() - 1000);
+      await testApp.refreshTokenRepository.save(stored);
+
+      const response = await request(testApp.app.getHttpServer())
+        .post('/auth/refresh')
+        .send({ refreshToken })
+        .expect(401);
+
+      expect(response.body.code).toBe('REFRESH_TOKEN_EXPIRED');
+    });
+  });
+
+  describe('session management', () => {
+    it('lists active sessions without token hashes or raw tokens', async () => {
+      const { token } = await signupUser(testApp.app, {
+        email: 'sessions@example.com',
+      });
+
+      const response = await request(testApp.app.getHttpServer())
+        .get('/auth/sessions')
+        .set('Authorization', bearerToken(token))
+        .expect(200);
+
+      expect(response.body).toHaveLength(1);
+      expect(response.body[0]).toMatchObject({
+        id: expect.any(String),
+        createdAt: expect.any(String),
+        expiresAt: expect.any(String),
+      });
+      expect(response.body[0]).not.toHaveProperty('tokenHash');
+      expect(response.body[0]).not.toHaveProperty('refreshToken');
+    });
+
+    it('logout revokes only the submitted current session', async () => {
+      const { token, refreshToken, payload } = await signupUser(testApp.app, {
+        email: 'logout@example.com',
+      });
+      const secondLogin = await loginUser(testApp.app, payload.email);
+
+      await request(testApp.app.getHttpServer())
+        .post('/auth/logout')
+        .set('Authorization', bearerToken(token))
+        .send({ refreshToken })
+        .expect(200);
+
+      await request(testApp.app.getHttpServer())
+        .post('/auth/refresh')
+        .send({ refreshToken: secondLogin.refreshToken })
+        .expect(200);
+
+      const tokens = await testApp.refreshTokenRepository.find({
+        order: { createdAt: 'ASC' },
+      });
+      expect(tokens[0].isRevoked).toBe(true);
+      expect(tokens.filter((tokenRow) => tokenRow.isRevoked)).toHaveLength(2);
+    });
+
+    it('logout-all revokes every active session for the user', async () => {
+      const { token, payload } = await signupUser(testApp.app, {
+        email: 'logout-all@example.com',
+      });
+      await loginUser(testApp.app, payload.email);
+
+      await request(testApp.app.getHttpServer())
+        .post('/auth/logout-all')
+        .set('Authorization', bearerToken(token))
+        .expect(200);
+
+      const tokens = await testApp.refreshTokenRepository.find();
+      expect(tokens.every((tokenRow) => tokenRow.isRevoked)).toBe(true);
+    });
+
+    it('deletes one session by id', async () => {
+      const { token } = await signupUser(testApp.app, {
+        email: 'delete-session@example.com',
+      });
+      const session = await testApp.refreshTokenRepository.findOneByOrFail({
+        isRevoked: false,
+      });
+
+      await request(testApp.app.getHttpServer())
+        .delete(`/auth/sessions/${session.id}`)
+        .set('Authorization', bearerToken(token))
+        .expect(200);
+
+      const revoked = await testApp.refreshTokenRepository.findOneByOrFail({
+        id: session.id,
+      });
+      expect(revoked.isRevoked).toBe(true);
+    });
+
+    it('returns 404 when deleting another user session', async () => {
+      const first = await signupUser(testApp.app, {
+        email: 'first-session@example.com',
+      });
+      const second = await signupUser(testApp.app, {
+        email: 'second-session@example.com',
+      });
+      const secondSession = await testApp.refreshTokenRepository.findOneByOrFail(
+        {
+          userId: second.user.id,
+        },
+      );
+
+      await request(testApp.app.getHttpServer())
+        .delete(`/auth/sessions/${secondSession.id}`)
+        .set('Authorization', bearerToken(first.token))
+        .expect(404);
+    });
+  });
+
+  describe('protected route token rules and password changes', () => {
+    it('rejects refresh tokens used as bearer access tokens', async () => {
+      const { refreshToken } = await signupUser(testApp.app, {
+        email: 'refresh-as-access@example.com',
+      });
+
+      await request(testApp.app.getHttpServer())
+        .get('/auth/sessions')
+        .set('Authorization', bearerToken(refreshToken))
+        .expect(401);
+    });
+
+    it('password change invalidates all active refresh sessions', async () => {
+      const { token, refreshToken, payload, user } = await signupUser(
+        testApp.app,
+        {
+          email: 'password-change@example.com',
+        },
+      );
+
+      await request(testApp.app.getHttpServer())
+        .put(`/users/${user.id}`)
+        .set('Authorization', bearerToken(token))
+        .send({
+          name: payload.name,
+          email: payload.email,
+          password: 'NewPassword123!',
+        })
+        .expect(200);
+
+      const tokens = await testApp.refreshTokenRepository.find();
+      expect(tokens.every((tokenRow) => tokenRow.isRevoked)).toBe(true);
+
+      const response = await request(testApp.app.getHttpServer())
+        .post('/auth/refresh')
+        .send({ refreshToken })
+        .expect(401);
+
+      expect(response.body.code).toBe('REFRESH_TOKEN_REUSE_DETECTED');
     });
   });
 });

--- a/test/helpers/auth.ts
+++ b/test/helpers/auth.ts
@@ -12,6 +12,7 @@ export interface SignupPayload {
 export interface AuthResult {
   payload: SignupPayload;
   token: string;
+  refreshToken: string;
   user: {
     id: number;
     name: string;
@@ -42,7 +43,8 @@ export async function signupUser(
 
   return {
     payload,
-    token: response.body.access_token,
+    token: response.body.accessToken,
+    refreshToken: response.body.refreshToken,
     user: response.body.user,
   };
 }
@@ -55,7 +57,7 @@ export async function loginUser(
   const response = await request(app.getHttpServer())
     .post('/auth/login')
     .send({ email, password })
-    .expect(201);
+    .expect(200);
 
   return {
     payload: {
@@ -63,7 +65,8 @@ export async function loginUser(
       email,
       password,
     },
-    token: response.body.access_token,
+    token: response.body.accessToken,
+    refreshToken: response.body.refreshToken,
     user: response.body.user,
   };
 }

--- a/test/helpers/e2e-app.ts
+++ b/test/helpers/e2e-app.ts
@@ -3,6 +3,8 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { DataSource, Repository } from 'typeorm';
 import { AppModule } from '../../src/app.module';
+import { RefreshToken } from '../../src/auth/entities/refresh-token.entity';
+import { GlobalExceptionFilter } from '../../src/exception/globalException.filter';
 import { User } from '../../src/users/user.entity';
 
 export interface E2eTestApp {
@@ -10,6 +12,7 @@ export interface E2eTestApp {
   moduleFixture: TestingModule;
   dataSource: DataSource;
   userRepository: Repository<User>;
+  refreshTokenRepository: Repository<RefreshToken>;
 }
 
 export async function createE2eApp(): Promise<E2eTestApp> {
@@ -25,6 +28,7 @@ export async function createE2eApp(): Promise<E2eTestApp> {
       transform: true,
     }),
   );
+  app.useGlobalFilters(new GlobalExceptionFilter());
   await app.init();
 
   return {
@@ -33,6 +37,9 @@ export async function createE2eApp(): Promise<E2eTestApp> {
     dataSource: moduleFixture.get(DataSource),
     userRepository: moduleFixture.get<Repository<User>>(
       getRepositoryToken(User),
+    ),
+    refreshTokenRepository: moduleFixture.get<Repository<RefreshToken>>(
+      getRepositoryToken(RefreshToken),
     ),
   };
 }


### PR DESCRIPTION
This PR upgrades the existing authentication system from a short-lived access token model to a production-grade session authentication architecture.

Previously, users received only an access token (access_token + expires_in) during login/signup. Once the token expired, users were required to authenticate again, resulting in poor user experience and limited session security controls.

This implementation introduces refresh token-based session management with rotation, reuse detection, per-device session tracking, and complete logout capabilities while maintaining the existing JWT access token flow.
closes #9 