### PR TITLE
> feat(subscriptions): implement fan-to-creator subscription API

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -3,6 +3,7 @@ import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { UsersModule } from './users/users.module';
 import { AuthModule } from './auth/auth.module';
+import { SubscriptionsModule } from './subscriptions/subscriptions.module';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { CacheModule } from '@nestjs/cache-manager';
@@ -31,6 +32,7 @@ import { RateLimitService } from './common/services/rate-limit.service';
     MonitoringModule,
     HealthModule,
     AuthModule,
+    SubscriptionsModule,
   ],
   controllers: [AppController],
   providers: [AppService, RateLimitService],

--- a/src/migrations/1769040000000-CreateSubscriptions.ts
+++ b/src/migrations/1769040000000-CreateSubscriptions.ts
@@ -1,0 +1,108 @@
+import {
+  MigrationInterface,
+  QueryRunner,
+  Table,
+  TableForeignKey,
+  TableIndex,
+} from 'typeorm';
+
+export class CreateSubscriptions1769040000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'subscriptions',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            generationStrategy: 'uuid',
+            isGenerated: true,
+          },
+          {
+            name: 'fanId',
+            type: 'int',
+          },
+          {
+            name: 'creatorId',
+            type: 'int',
+          },
+          {
+            name: 'status',
+            type: 'varchar',
+            default: "'active'",
+          },
+          {
+            name: 'subscribedAt',
+            type: 'timestamp',
+            default: 'CURRENT_TIMESTAMP',
+          },
+          {
+            name: 'cancelledAt',
+            type: 'timestamp',
+            isNullable: true,
+          },
+        ],
+      }),
+    );
+
+    await queryRunner.createForeignKey(
+      'subscriptions',
+      new TableForeignKey({
+        columnNames: ['fanId'],
+        referencedTableName: 'users',
+        referencedColumnNames: ['id'],
+        onDelete: 'CASCADE',
+      }),
+    );
+    await queryRunner.createForeignKey(
+      'subscriptions',
+      new TableForeignKey({
+        columnNames: ['creatorId'],
+        referencedTableName: 'users',
+        referencedColumnNames: ['id'],
+        onDelete: 'CASCADE',
+      }),
+    );
+
+    // One row per fan+creator pair (re-subscribe reactivates the same row).
+    await queryRunner.createIndex(
+      'subscriptions',
+      new TableIndex({
+        name: 'UQ_SUBSCRIPTIONS_FAN_CREATOR',
+        columnNames: ['fanId', 'creatorId'],
+        isUnique: true,
+      }),
+    );
+    await queryRunner.createIndex(
+      'subscriptions',
+      new TableIndex({
+        name: 'IDX_SUBSCRIPTIONS_CREATOR_STATUS',
+        columnNames: ['creatorId', 'status'],
+      }),
+    );
+    await queryRunner.createIndex(
+      'subscriptions',
+      new TableIndex({
+        name: 'IDX_SUBSCRIPTIONS_FAN_STATUS',
+        columnNames: ['fanId', 'status'],
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropIndex(
+      'subscriptions',
+      'IDX_SUBSCRIPTIONS_FAN_STATUS',
+    );
+    await queryRunner.dropIndex(
+      'subscriptions',
+      'IDX_SUBSCRIPTIONS_CREATOR_STATUS',
+    );
+    await queryRunner.dropIndex(
+      'subscriptions',
+      'UQ_SUBSCRIPTIONS_FAN_CREATOR',
+    );
+    await queryRunner.dropTable('subscriptions');
+  }
+}

--- a/src/migrations/appDataSource.db.ts
+++ b/src/migrations/appDataSource.db.ts
@@ -1,6 +1,7 @@
 import { ConfigService } from '@nestjs/config';
 import { User } from 'src/users/user.entity';
 import { RefreshToken } from 'src/auth/entities/refresh-token.entity';
+import { Subscription } from 'src/subscriptions/subscription.entity';
 import { DataSourceOptions } from 'typeorm';
 
 export function dataOption(configService: ConfigService): DataSourceOptions {
@@ -11,7 +12,7 @@ export function dataOption(configService: ConfigService): DataSourceOptions {
     username: configService.get<string>('DB_USERNAME'),
     password: configService.get<string>('DB_PASSWORD'),
     database: configService.get<string>('DB_NAME'),
-    entities: [User, RefreshToken],
+    entities: [User, RefreshToken, Subscription],
     synchronize: true,
   };
 }

--- a/src/subscriptions/creators.controller.ts
+++ b/src/subscriptions/creators.controller.ts
@@ -1,0 +1,47 @@
+import { Controller, Get, Query, Req, UseGuards } from '@nestjs/common';
+import { Request } from 'express';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { SubscriptionsService } from './subscriptions.service';
+import { SubscriptionQueryDto } from './dtos/subscription-query.dto';
+import { SubscriberResponseDto } from './dtos/subscriber-response.dto';
+import { PaginatedResponseDto } from '../users/dtos/paginated-response.dto';
+
+interface AuthenticatedRequest extends Request {
+  user: {
+    userId: number;
+    email: string;
+    username: string;
+  };
+}
+
+@ApiTags('Creators')
+@ApiBearerAuth('JWT-auth')
+@Controller('creators')
+@UseGuards(JwtAuthGuard)
+export class CreatorsController {
+  constructor(private readonly subscriptionsService: SubscriptionsService) {}
+
+  @Get('me/subscribers')
+  @ApiOperation({
+    summary: 'Creator lists their own subscribers (subscriber count + fan IDs)',
+  })
+  @ApiResponse({
+    status: 200,
+    description:
+      'Paginated list of active subscribers. `pagination.totalCount` is the subscriber count.',
+    type: PaginatedResponseDto,
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  async listMySubscribers(
+    @Req() req: AuthenticatedRequest,
+    @Query() query: SubscriptionQueryDto,
+  ): Promise<PaginatedResponseDto<SubscriberResponseDto>> {
+    return this.subscriptionsService.listMySubscribers(req.user.userId, query);
+  }
+}

--- a/src/subscriptions/dtos/create-subscription.dto.ts
+++ b/src/subscriptions/dtos/create-subscription.dto.ts
@@ -1,0 +1,14 @@
+import { IsInt, Min } from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class CreateSubscriptionDto {
+  @ApiProperty({
+    description: 'ID of the creator the fan wants to subscribe to',
+    example: 42,
+  })
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  creatorId: number;
+}

--- a/src/subscriptions/dtos/subscriber-response.dto.ts
+++ b/src/subscriptions/dtos/subscriber-response.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class SubscriberResponseDto {
+  @ApiProperty({ description: 'Subscription ID', format: 'uuid' })
+  id: string;
+
+  @ApiProperty({ description: 'ID of the subscribing fan' })
+  fanId: number;
+
+  @ApiProperty({ type: String, format: 'date-time' })
+  subscribedAt: Date;
+}

--- a/src/subscriptions/dtos/subscription-query.dto.ts
+++ b/src/subscriptions/dtos/subscription-query.dto.ts
@@ -1,0 +1,29 @@
+import { IsOptional, IsInt, Min, Max } from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+export class SubscriptionQueryDto {
+  @ApiPropertyOptional({
+    description: 'Page number (1-based)',
+    minimum: 1,
+    default: 1,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @ApiPropertyOptional({
+    description: 'Page size',
+    minimum: 1,
+    maximum: 100,
+    default: 20,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number = 20;
+}

--- a/src/subscriptions/dtos/subscription-response.dto.ts
+++ b/src/subscriptions/dtos/subscription-response.dto.ts
@@ -1,0 +1,22 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { SubscriptionStatus } from '../subscription.entity';
+
+export class SubscriptionResponseDto {
+  @ApiProperty({ format: 'uuid' })
+  id: string;
+
+  @ApiProperty({ description: 'ID of the subscribing fan' })
+  fanId: number;
+
+  @ApiProperty({ description: 'ID of the subscribed-to creator' })
+  creatorId: number;
+
+  @ApiProperty({ enum: ['active', 'cancelled'] })
+  status: SubscriptionStatus;
+
+  @ApiProperty({ type: String, format: 'date-time' })
+  subscribedAt: Date;
+
+  @ApiProperty({ type: String, format: 'date-time', nullable: true })
+  cancelledAt: Date | null;
+}

--- a/src/subscriptions/subscription.entity.ts
+++ b/src/subscriptions/subscription.entity.ts
@@ -1,0 +1,43 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { User } from '../users/user.entity';
+
+export type SubscriptionStatus = 'active' | 'cancelled';
+
+@Entity('subscriptions')
+// One row per fan+creator pair. Re-subscribing reactivates the same row, so a
+// plain unique constraint on the pair also guarantees a single active row.
+@Index(['fanId', 'creatorId'], { unique: true })
+@Index(['creatorId', 'status'])
+@Index(['fanId', 'status'])
+export class Subscription {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'int' })
+  fanId: number;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  fan: User;
+
+  @Column({ type: 'int' })
+  creatorId: number;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  creator: User;
+
+  @Column({ type: 'varchar', default: 'active' })
+  status: SubscriptionStatus;
+
+  @CreateDateColumn({ type: 'timestamp' })
+  subscribedAt: Date;
+
+  @Column({ type: 'timestamp', nullable: true })
+  cancelledAt: Date | null;
+}

--- a/src/subscriptions/subscriptions.controller.spec.ts
+++ b/src/subscriptions/subscriptions.controller.spec.ts
@@ -1,0 +1,89 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { Request } from 'express';
+import { SubscriptionsController } from './subscriptions.controller';
+import { CreatorsController } from './creators.controller';
+import { SubscriptionsService } from './subscriptions.service';
+
+interface AuthenticatedRequest extends Request {
+  user: { userId: number; email: string; username: string };
+}
+
+const reqFor = (userId: number) =>
+  ({ user: { userId, email: 'x', username: 'x' } }) as AuthenticatedRequest;
+
+describe('Subscription controllers', () => {
+  let subscriptionsController: SubscriptionsController;
+  let creatorsController: CreatorsController;
+  let service: jest.Mocked<SubscriptionsService>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [SubscriptionsController, CreatorsController],
+      providers: [
+        {
+          provide: SubscriptionsService,
+          useValue: {
+            subscribe: jest.fn(),
+            cancel: jest.fn(),
+            listMySubscriptions: jest.fn(),
+            listMySubscribers: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    subscriptionsController = module.get(SubscriptionsController);
+    creatorsController = module.get(CreatorsController);
+    service = module.get(SubscriptionsService);
+  });
+
+  it('subscribe passes the authenticated fan id to the service', async () => {
+    (service.subscribe as jest.Mock).mockResolvedValue({ id: 'a' });
+
+    await subscriptionsController.subscribe(reqFor(5), { creatorId: 9 });
+
+    expect(service.subscribe).toHaveBeenCalledWith(5, { creatorId: 9 });
+  });
+
+  it('cancel passes the authenticated fan id and creator id', async () => {
+    (service.cancel as jest.Mock).mockResolvedValue({ id: 'a' });
+
+    await subscriptionsController.cancel(reqFor(5), 9);
+
+    expect(service.cancel).toHaveBeenCalledWith(5, 9);
+  });
+
+  it('listMySubscriptions uses the authenticated user id', async () => {
+    (service.listMySubscriptions as jest.Mock).mockResolvedValue({
+      data: [],
+      pagination: { hasMore: false, totalCount: 0, limit: 20 },
+    });
+
+    await subscriptionsController.listMySubscriptions(reqFor(5), {
+      page: 1,
+      limit: 20,
+    });
+
+    expect(service.listMySubscriptions).toHaveBeenCalledWith(5, {
+      page: 1,
+      limit: 20,
+    });
+  });
+
+  it('listMySubscribers scopes to the authenticated creator (ownership)', async () => {
+    (service.listMySubscribers as jest.Mock).mockResolvedValue({
+      data: [],
+      pagination: { hasMore: false, totalCount: 0, limit: 20 },
+    });
+
+    await creatorsController.listMySubscribers(reqFor(5), {
+      page: 1,
+      limit: 20,
+    });
+
+    expect(service.listMySubscribers).toHaveBeenCalledWith(5, {
+      page: 1,
+      limit: 20,
+    });
+  });
+});

--- a/src/subscriptions/subscriptions.controller.ts
+++ b/src/subscriptions/subscriptions.controller.ts
@@ -1,0 +1,103 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  Param,
+  ParseIntPipe,
+  Post,
+  Query,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+import { Request } from 'express';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiParam,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { SubscriptionsService } from './subscriptions.service';
+import { CreateSubscriptionDto } from './dtos/create-subscription.dto';
+import { SubscriptionQueryDto } from './dtos/subscription-query.dto';
+import { SubscriptionResponseDto } from './dtos/subscription-response.dto';
+import { PaginatedResponseDto } from '../users/dtos/paginated-response.dto';
+
+interface AuthenticatedRequest extends Request {
+  user: {
+    userId: number;
+    email: string;
+    username: string;
+  };
+}
+
+@ApiTags('Subscriptions')
+@ApiBearerAuth('JWT-auth')
+@Controller('subscriptions')
+@UseGuards(JwtAuthGuard)
+export class SubscriptionsController {
+  constructor(private readonly subscriptionsService: SubscriptionsService) {}
+
+  @Post()
+  @ApiOperation({ summary: 'Fan subscribes to a creator' })
+  @ApiResponse({
+    status: 201,
+    description: 'Subscription created (or reactivated after a prior cancel)',
+    type: SubscriptionResponseDto,
+  })
+  @ApiResponse({ status: 400, description: 'Cannot subscribe to yourself' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 404, description: 'Creator not found' })
+  @ApiResponse({
+    status: 409,
+    description: 'Active subscription to this creator already exists',
+  })
+  async subscribe(
+    @Req() req: AuthenticatedRequest,
+    @Body() dto: CreateSubscriptionDto,
+  ): Promise<SubscriptionResponseDto> {
+    return this.subscriptionsService.subscribe(req.user.userId, dto);
+  }
+
+  @Delete(':creatorId')
+  @HttpCode(200)
+  @ApiOperation({ summary: 'Fan cancels a subscription to a creator' })
+  @ApiParam({ name: 'creatorId', description: 'Creator ID', type: Number })
+  @ApiResponse({
+    status: 200,
+    description: 'Subscription cancelled',
+    type: SubscriptionResponseDto,
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({
+    status: 404,
+    description: 'No active subscription to this creator',
+  })
+  async cancel(
+    @Req() req: AuthenticatedRequest,
+    @Param('creatorId', ParseIntPipe) creatorId: number,
+  ): Promise<SubscriptionResponseDto> {
+    return this.subscriptionsService.cancel(req.user.userId, creatorId);
+  }
+
+  @Get('me')
+  @ApiOperation({ summary: 'Fan lists their own active subscriptions' })
+  @ApiResponse({
+    status: 200,
+    description: 'Paginated list of active subscriptions',
+    type: PaginatedResponseDto,
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  async listMySubscriptions(
+    @Req() req: AuthenticatedRequest,
+    @Query() query: SubscriptionQueryDto,
+  ): Promise<PaginatedResponseDto<SubscriptionResponseDto>> {
+    return this.subscriptionsService.listMySubscriptions(
+      req.user.userId,
+      query,
+    );
+  }
+}

--- a/src/subscriptions/subscriptions.module.ts
+++ b/src/subscriptions/subscriptions.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Subscription } from './subscription.entity';
+import { User } from '../users/user.entity';
+import { SubscriptionsService } from './subscriptions.service';
+import { SubscriptionsController } from './subscriptions.controller';
+import { CreatorsController } from './creators.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Subscription, User])],
+  providers: [SubscriptionsService],
+  controllers: [SubscriptionsController, CreatorsController],
+  exports: [SubscriptionsService],
+})
+export class SubscriptionsModule {}

--- a/src/subscriptions/subscriptions.service.spec.ts
+++ b/src/subscriptions/subscriptions.service.spec.ts
@@ -1,0 +1,232 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import {
+  BadRequestException,
+  ConflictException,
+  NotFoundException,
+} from '@nestjs/common';
+import { Repository } from 'typeorm';
+import { SubscriptionsService } from './subscriptions.service';
+import { Subscription } from './subscription.entity';
+import { User } from '../users/user.entity';
+
+describe('SubscriptionsService', () => {
+  let service: SubscriptionsService;
+  let subscriptionRepo: jest.Mocked<Repository<Subscription>>;
+  let userRepo: jest.Mocked<Repository<User>>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SubscriptionsService,
+        {
+          provide: getRepositoryToken(Subscription),
+          useValue: {
+            findOne: jest.fn(),
+            findAndCount: jest.fn(),
+            create: jest.fn(),
+            save: jest.fn(),
+          },
+        },
+        {
+          provide: getRepositoryToken(User),
+          useValue: {
+            findOne: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get(SubscriptionsService);
+    subscriptionRepo = module.get(getRepositoryToken(Subscription));
+    userRepo = module.get(getRepositoryToken(User));
+  });
+
+  describe('subscribe', () => {
+    it('rejects subscribing to yourself', async () => {
+      await expect(
+        service.subscribe(1, { creatorId: 1 }),
+      ).rejects.toBeInstanceOf(BadRequestException);
+      expect(userRepo.findOne).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFound when the creator does not exist', async () => {
+      userRepo.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.subscribe(1, { creatorId: 99 }),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('creates a new active subscription', async () => {
+      userRepo.findOne.mockResolvedValue({ id: 2 } as User);
+      subscriptionRepo.findOne.mockResolvedValue(null);
+      const created = {
+        fanId: 1,
+        creatorId: 2,
+        status: 'active',
+        cancelledAt: null,
+      } as Subscription;
+      subscriptionRepo.create.mockReturnValue(created);
+      subscriptionRepo.save.mockResolvedValue({
+        ...created,
+        id: 'uuid-1',
+        subscribedAt: new Date(),
+      });
+
+      const result = await service.subscribe(1, { creatorId: 2 });
+
+      expect(result).toMatchObject({
+        id: 'uuid-1',
+        fanId: 1,
+        creatorId: 2,
+        status: 'active',
+        cancelledAt: null,
+      });
+      expect(subscriptionRepo.create).toHaveBeenCalled();
+    });
+
+    it('returns 409 when an active subscription already exists', async () => {
+      userRepo.findOne.mockResolvedValue({ id: 2 } as User);
+      subscriptionRepo.findOne.mockResolvedValue({
+        id: 'uuid-1',
+        fanId: 1,
+        creatorId: 2,
+        status: 'active',
+      } as Subscription);
+
+      await expect(
+        service.subscribe(1, { creatorId: 2 }),
+      ).rejects.toBeInstanceOf(ConflictException);
+      expect(subscriptionRepo.save).not.toHaveBeenCalled();
+    });
+
+    it('reactivates a previously cancelled subscription', async () => {
+      userRepo.findOne.mockResolvedValue({ id: 2 } as User);
+      const cancelled = {
+        id: 'uuid-1',
+        fanId: 1,
+        creatorId: 2,
+        status: 'cancelled',
+        cancelledAt: new Date('2020-01-01'),
+        subscribedAt: new Date('2019-01-01'),
+      } as Subscription;
+      subscriptionRepo.findOne.mockResolvedValue(cancelled);
+      subscriptionRepo.save.mockImplementation(async (s) => s as Subscription);
+
+      const result = await service.subscribe(1, { creatorId: 2 });
+
+      expect(result.status).toBe('active');
+      expect(result.cancelledAt).toBeNull();
+      expect(subscriptionRepo.create).not.toHaveBeenCalled();
+      expect(subscriptionRepo.save).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'uuid-1', status: 'active' }),
+      );
+    });
+  });
+
+  describe('cancel', () => {
+    it('cancels an active subscription', async () => {
+      const active = {
+        id: 'uuid-1',
+        fanId: 1,
+        creatorId: 2,
+        status: 'active',
+        cancelledAt: null,
+      } as Subscription;
+      subscriptionRepo.findOne.mockResolvedValue(active);
+      subscriptionRepo.save.mockImplementation(async (s) => s as Subscription);
+
+      const result = await service.cancel(1, 2);
+
+      expect(result.status).toBe('cancelled');
+      expect(result.cancelledAt).toBeInstanceOf(Date);
+    });
+
+    it('throws NotFound when there is no active subscription', async () => {
+      subscriptionRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.cancel(1, 2)).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('listMySubscriptions', () => {
+    it('returns only active subscriptions with pagination meta', async () => {
+      subscriptionRepo.findAndCount.mockResolvedValue([
+        [
+          {
+            id: 'uuid-1',
+            fanId: 1,
+            creatorId: 2,
+            status: 'active',
+            subscribedAt: new Date(),
+            cancelledAt: null,
+          } as Subscription,
+        ],
+        1,
+      ]);
+
+      const result = await service.listMySubscriptions(1, {
+        page: 1,
+        limit: 20,
+      });
+
+      expect(result.data).toHaveLength(1);
+      expect(result.pagination).toMatchObject({
+        totalCount: 1,
+        limit: 20,
+        hasMore: false,
+      });
+      expect(subscriptionRepo.findAndCount).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { fanId: 1, status: 'active' },
+          skip: 0,
+          take: 20,
+        }),
+      );
+    });
+
+    it('reports hasMore when more pages exist', async () => {
+      subscriptionRepo.findAndCount.mockResolvedValue([[], 50]);
+
+      const result = await service.listMySubscriptions(1, {
+        page: 1,
+        limit: 20,
+      });
+
+      expect(result.pagination.hasMore).toBe(true);
+    });
+  });
+
+  describe('listMySubscribers', () => {
+    it('returns subscriber ids and count for the creator', async () => {
+      subscriptionRepo.findAndCount.mockResolvedValue([
+        [
+          {
+            id: 'uuid-1',
+            fanId: 7,
+            creatorId: 2,
+            status: 'active',
+            subscribedAt: new Date(),
+            cancelledAt: null,
+          } as Subscription,
+        ],
+        1,
+      ]);
+
+      const result = await service.listMySubscribers(2, { page: 1, limit: 20 });
+
+      expect(result.data).toEqual([
+        expect.objectContaining({ id: 'uuid-1', fanId: 7 }),
+      ]);
+      expect(result.pagination.totalCount).toBe(1);
+      expect(subscriptionRepo.findAndCount).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { creatorId: 2, status: 'active' },
+        }),
+      );
+    });
+  });
+});

--- a/src/subscriptions/subscriptions.service.ts
+++ b/src/subscriptions/subscriptions.service.ts
@@ -1,0 +1,188 @@
+import {
+  BadRequestException,
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Subscription } from './subscription.entity';
+import { User } from '../users/user.entity';
+import { CreateSubscriptionDto } from './dtos/create-subscription.dto';
+import { SubscriptionQueryDto } from './dtos/subscription-query.dto';
+import { SubscriptionResponseDto } from './dtos/subscription-response.dto';
+import { SubscriberResponseDto } from './dtos/subscriber-response.dto';
+import {
+  PaginatedResponseDto,
+  PaginationMetaDto,
+} from '../users/dtos/paginated-response.dto';
+
+@Injectable()
+export class SubscriptionsService {
+  constructor(
+    @InjectRepository(Subscription)
+    private readonly subscriptionRepository: Repository<Subscription>,
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
+  ) {}
+
+  /**
+   * Fan subscribes to a creator.
+   *
+   * Idempotency / re-subscribe choice: we keep a single row per fan+creator
+   * pair. A brand-new subscription inserts a row; re-subscribing after a cancel
+   * reactivates that same row (status -> active, cancelledAt cleared,
+   * subscribedAt refreshed) rather than inserting a duplicate. Attempting to
+   * subscribe while an active subscription already exists returns 409.
+   */
+  async subscribe(
+    fanId: number,
+    dto: CreateSubscriptionDto,
+  ): Promise<SubscriptionResponseDto> {
+    const { creatorId } = dto;
+
+    if (creatorId === fanId) {
+      throw new BadRequestException('A fan cannot subscribe to themselves');
+    }
+
+    const creator = await this.userRepository.findOne({
+      where: { id: creatorId },
+    });
+    if (!creator) {
+      throw new NotFoundException('Creator not found');
+    }
+
+    const existing = await this.subscriptionRepository.findOne({
+      where: { fanId, creatorId },
+    });
+
+    if (existing) {
+      if (existing.status === 'active') {
+        throw new ConflictException(
+          'An active subscription to this creator already exists',
+        );
+      }
+
+      // Reactivate the previously cancelled subscription.
+      existing.status = 'active';
+      existing.cancelledAt = null;
+      existing.subscribedAt = new Date();
+      const reactivated = await this.subscriptionRepository.save(existing);
+      return this.toResponse(reactivated);
+    }
+
+    const subscription = this.subscriptionRepository.create({
+      fanId,
+      creatorId,
+      status: 'active',
+      cancelledAt: null,
+    });
+    const saved = await this.subscriptionRepository.save(subscription);
+    return this.toResponse(saved);
+  }
+
+  /**
+   * Fan cancels an active subscription to a creator.
+   */
+  async cancel(
+    fanId: number,
+    creatorId: number,
+  ): Promise<SubscriptionResponseDto> {
+    const subscription = await this.subscriptionRepository.findOne({
+      where: { fanId, creatorId, status: 'active' },
+    });
+
+    if (!subscription) {
+      throw new NotFoundException('No active subscription to this creator');
+    }
+
+    subscription.status = 'cancelled';
+    subscription.cancelledAt = new Date();
+    const saved = await this.subscriptionRepository.save(subscription);
+    return this.toResponse(saved);
+  }
+
+  /**
+   * Fan lists their own active subscriptions (paginated).
+   */
+  async listMySubscriptions(
+    fanId: number,
+    query: SubscriptionQueryDto,
+  ): Promise<PaginatedResponseDto<SubscriptionResponseDto>> {
+    const { page, limit } = this.normalizePagination(query);
+
+    const [rows, totalCount] = await this.subscriptionRepository.findAndCount({
+      where: { fanId, status: 'active' },
+      order: { subscribedAt: 'DESC' },
+      skip: (page - 1) * limit,
+      take: limit,
+    });
+
+    return {
+      data: rows.map((row) => this.toResponse(row)),
+      pagination: this.buildMeta(page, limit, totalCount),
+    };
+  }
+
+  /**
+   * Creator lists their own subscribers (paginated). Ownership is enforced by
+   * the caller passing their authenticated user id as creatorId.
+   */
+  async listMySubscribers(
+    creatorId: number,
+    query: SubscriptionQueryDto,
+  ): Promise<PaginatedResponseDto<SubscriberResponseDto>> {
+    const { page, limit } = this.normalizePagination(query);
+
+    const [rows, totalCount] = await this.subscriptionRepository.findAndCount({
+      where: { creatorId, status: 'active' },
+      order: { subscribedAt: 'DESC' },
+      skip: (page - 1) * limit,
+      take: limit,
+    });
+
+    const data: SubscriberResponseDto[] = rows.map((row) => ({
+      id: row.id,
+      fanId: row.fanId,
+      subscribedAt: row.subscribedAt,
+    }));
+
+    return {
+      data,
+      pagination: this.buildMeta(page, limit, totalCount),
+    };
+  }
+
+  private normalizePagination(query: SubscriptionQueryDto): {
+    page: number;
+    limit: number;
+  } {
+    return {
+      page: query.page && query.page > 0 ? query.page : 1,
+      limit: query.limit && query.limit > 0 ? query.limit : 20,
+    };
+  }
+
+  private buildMeta(
+    page: number,
+    limit: number,
+    totalCount: number,
+  ): PaginationMetaDto {
+    return {
+      hasMore: page * limit < totalCount,
+      totalCount,
+      limit,
+    };
+  }
+
+  private toResponse(subscription: Subscription): SubscriptionResponseDto {
+    return {
+      id: subscription.id,
+      fanId: subscription.fanId,
+      creatorId: subscription.creatorId,
+      status: subscription.status,
+      subscribedAt: subscription.subscribedAt,
+      cancelledAt: subscription.cancelledAt,
+    };
+  }
+}

--- a/test/subscriptions.e2e-spec.ts
+++ b/test/subscriptions.e2e-spec.ts
@@ -1,0 +1,224 @@
+import * as request from 'supertest';
+import { clearDatabase, createE2eApp, E2eTestApp } from './helpers/e2e-app';
+import { bearerToken, signupUser } from './helpers/auth';
+
+describe('Subscriptions E2E', () => {
+  let testApp: E2eTestApp;
+
+  beforeAll(async () => {
+    testApp = await createE2eApp();
+  });
+
+  beforeEach(async () => {
+    await clearDatabase(testApp.dataSource);
+  });
+
+  afterAll(async () => {
+    await testApp.app.close();
+  });
+
+  const server = () => testApp.app.getHttpServer();
+
+  async function makeFanAndCreator() {
+    const fan = await signupUser(testApp.app, { email: 'fan@example.com' });
+    const creator = await signupUser(testApp.app, {
+      email: 'creator@example.com',
+    });
+    return { fan, creator };
+  }
+
+  it('rejects unauthenticated subscribe requests', async () => {
+    await request(server())
+      .post('/subscriptions')
+      .send({ creatorId: 1 })
+      .expect(401);
+  });
+
+  it('lets a fan subscribe to a creator', async () => {
+    const { fan, creator } = await makeFanAndCreator();
+
+    const response = await request(server())
+      .post('/subscriptions')
+      .set('Authorization', bearerToken(fan.token))
+      .send({ creatorId: creator.user.id })
+      .expect(201);
+
+    expect(response.body).toMatchObject({
+      id: expect.any(String),
+      fanId: fan.user.id,
+      creatorId: creator.user.id,
+      status: 'active',
+      cancelledAt: null,
+    });
+  });
+
+  it('prevents a fan from subscribing to themselves', async () => {
+    const { fan } = await makeFanAndCreator();
+
+    await request(server())
+      .post('/subscriptions')
+      .set('Authorization', bearerToken(fan.token))
+      .send({ creatorId: fan.user.id })
+      .expect(400);
+  });
+
+  it('returns 404 when subscribing to a non-existent creator', async () => {
+    const { fan } = await makeFanAndCreator();
+
+    await request(server())
+      .post('/subscriptions')
+      .set('Authorization', bearerToken(fan.token))
+      .send({ creatorId: 999999 })
+      .expect(404);
+  });
+
+  it('returns 409 on a duplicate active subscription', async () => {
+    const { fan, creator } = await makeFanAndCreator();
+
+    await request(server())
+      .post('/subscriptions')
+      .set('Authorization', bearerToken(fan.token))
+      .send({ creatorId: creator.user.id })
+      .expect(201);
+
+    await request(server())
+      .post('/subscriptions')
+      .set('Authorization', bearerToken(fan.token))
+      .send({ creatorId: creator.user.id })
+      .expect(409);
+  });
+
+  it('lets a fan cancel a subscription and hides it from active lists', async () => {
+    const { fan, creator } = await makeFanAndCreator();
+
+    await request(server())
+      .post('/subscriptions')
+      .set('Authorization', bearerToken(fan.token))
+      .send({ creatorId: creator.user.id })
+      .expect(201);
+
+    const cancelled = await request(server())
+      .delete(`/subscriptions/${creator.user.id}`)
+      .set('Authorization', bearerToken(fan.token))
+      .expect(200);
+    expect(cancelled.body.status).toBe('cancelled');
+    expect(cancelled.body.cancelledAt).toEqual(expect.any(String));
+
+    const list = await request(server())
+      .get('/subscriptions/me')
+      .set('Authorization', bearerToken(fan.token))
+      .expect(200);
+    expect(list.body.data).toHaveLength(0);
+    expect(list.body.pagination.totalCount).toBe(0);
+  });
+
+  it('returns 404 when cancelling without an active subscription', async () => {
+    const { fan, creator } = await makeFanAndCreator();
+
+    await request(server())
+      .delete(`/subscriptions/${creator.user.id}`)
+      .set('Authorization', bearerToken(fan.token))
+      .expect(404);
+  });
+
+  it('reactivates the same subscription row when re-subscribing after a cancel', async () => {
+    const { fan, creator } = await makeFanAndCreator();
+
+    const first = await request(server())
+      .post('/subscriptions')
+      .set('Authorization', bearerToken(fan.token))
+      .send({ creatorId: creator.user.id })
+      .expect(201);
+
+    await request(server())
+      .delete(`/subscriptions/${creator.user.id}`)
+      .set('Authorization', bearerToken(fan.token))
+      .expect(200);
+
+    const second = await request(server())
+      .post('/subscriptions')
+      .set('Authorization', bearerToken(fan.token))
+      .send({ creatorId: creator.user.id })
+      .expect(201);
+
+    expect(second.body.id).toBe(first.body.id);
+    expect(second.body.status).toBe('active');
+    expect(second.body.cancelledAt).toBeNull();
+
+    const stored = await testApp.dataSource.query(
+      'SELECT count(*)::int AS count FROM subscriptions WHERE "fanId" = $1 AND "creatorId" = $2',
+      [fan.user.id, creator.user.id],
+    );
+    expect(stored[0].count).toBe(1);
+  });
+
+  it('lists a fan active subscriptions with pagination meta', async () => {
+    const { fan, creator } = await makeFanAndCreator();
+    const creator2 = await signupUser(testApp.app, {
+      email: 'creator2@example.com',
+    });
+
+    for (const c of [creator, creator2]) {
+      await request(server())
+        .post('/subscriptions')
+        .set('Authorization', bearerToken(fan.token))
+        .send({ creatorId: c.user.id })
+        .expect(201);
+    }
+
+    const page1 = await request(server())
+      .get('/subscriptions/me?page=1&limit=1')
+      .set('Authorization', bearerToken(fan.token))
+      .expect(200);
+
+    expect(page1.body.data).toHaveLength(1);
+    expect(page1.body.pagination).toMatchObject({
+      totalCount: 2,
+      limit: 1,
+      hasMore: true,
+    });
+  });
+
+  it('lets a creator list subscriber count and subscriber ids', async () => {
+    const { fan, creator } = await makeFanAndCreator();
+    const fan2 = await signupUser(testApp.app, { email: 'fan2@example.com' });
+
+    for (const f of [fan, fan2]) {
+      await request(server())
+        .post('/subscriptions')
+        .set('Authorization', bearerToken(f.token))
+        .send({ creatorId: creator.user.id })
+        .expect(201);
+    }
+
+    const response = await request(server())
+      .get('/creators/me/subscribers')
+      .set('Authorization', bearerToken(creator.token))
+      .expect(200);
+
+    expect(response.body.pagination.totalCount).toBe(2);
+    const fanIds = response.body.data.map((s: { fanId: number }) => s.fanId);
+    expect(fanIds).toEqual(expect.arrayContaining([fan.user.id, fan2.user.id]));
+  });
+
+  it('only shows a creator their own subscribers (ownership)', async () => {
+    const { fan, creator } = await makeFanAndCreator();
+    const otherCreator = await signupUser(testApp.app, {
+      email: 'other-creator@example.com',
+    });
+
+    await request(server())
+      .post('/subscriptions')
+      .set('Authorization', bearerToken(fan.token))
+      .send({ creatorId: creator.user.id })
+      .expect(201);
+
+    const response = await request(server())
+      .get('/creators/me/subscribers')
+      .set('Authorization', bearerToken(otherCreator.token))
+      .expect(200);
+
+    expect(response.body.pagination.totalCount).toBe(0);
+    expect(response.body.data).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
- Add Subscription entity with fanId, creatorId, status, subscribedAt, cancelledAt
- Unique constraint on fan+creator pair; re-subscribe reactivates existing row
- POST /subscriptions — fan subscribes to creator (409 on duplicate, 400 on self-subscribe)
- DELETE /subscriptions/:creatorId — fan cancels active subscription
- GET /subscriptions/me — fan lists active subscriptions (paginated)
- GET /creators/me/subscribers — creator lists their subscribers (paginated)
- Add migration 1769040000000-CreateSubscriptions
- 14 unit tests + 11 e2e tests, all passing

closes #21 