### PR TITLE
feat: add request correlation ID middleware (Closes #15)

### DIFF
--- a/docs/logging-monitoring.md
+++ b/docs/logging-monitoring.md
@@ -17,6 +17,22 @@
 - GlobalExceptionFilter logs all errors.
 - No sensitive data should be logged.
 
+### Request correlation IDs
+
+Every HTTP request is assigned an `X-Request-Id` header:
+
+- If the client sends `X-Request-Id`, that value is used.
+- Otherwise the server generates a UUID.
+- The ID is stored in request-scoped async context (`AsyncLocalStorage`) and included in all `AppLogger` output for that request.
+- Every API response includes `X-Request-Id` in response headers.
+- Error responses from `GlobalExceptionFilter` also include `requestId` in the JSON body for client-side error reporting.
+
+Example:
+
+```bash
+curl -i http://localhost:3000/users -H "X-Request-Id: my-trace-123"
+```
+
 ## Monitoring
 
 - Prometheus metrics exposed at `/metrics` (see `src/monitoring/monitoring.module.ts`).

--- a/package-lock.json
+++ b/package-lock.json
@@ -3390,7 +3390,7 @@
       "version": "1.15.41",
       "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.41.tgz",
       "integrity": "sha512-03nQq/082QRJJiOvp3FGbgxTGyyxMxohPTjhk/W9bD2J0tk4ukITI7goOhOO2WbaHn/lsPmo/zf8+DIXhwpgYQ==",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3434,6 +3434,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3450,6 +3451,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3466,6 +3468,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3482,6 +3485,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3498,6 +3502,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3514,6 +3519,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3530,6 +3536,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3546,6 +3553,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3562,6 +3570,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3578,6 +3587,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3594,6 +3604,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3610,6 +3621,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3623,14 +3635,14 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
       "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@swc/types": {
       "version": "0.1.27",
       "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.27.tgz",
       "integrity": "sha512-K6h3iUlqeM946U4sXFYeahefR1YBbXJvko+hv8WS8/0BNJ4OHiHRywMnQUJCqkR7Y9+hqQ1TvEpiKqUhz7NEFg==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/counter": "^0.1.3"

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { MiddlewareConsumer, Module, NestModule } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { UsersModule } from './users/users.module';
@@ -17,6 +17,7 @@ import { HealthModule } from './monitoring/health.module';
 import { ThrottleConfigModule } from './common/throttle/throttle.module';
 import { AuditModule } from './audit/audit.module';
 import { AdminModule } from './admin/admin.module';
+import { RequestIdMiddleware } from './common/middleware/request-id.middleware';
 
 @Module({
   imports: [
@@ -48,4 +49,8 @@ import { AdminModule } from './admin/admin.module';
   controllers: [AppController],
   providers: [AppService],
 })
-export class AppModule {}
+export class AppModule implements NestModule {
+  configure(consumer: MiddlewareConsumer): void {
+    consumer.apply(RequestIdMiddleware).forRoutes('*');
+  }
+}

--- a/src/common/middleware/request-id.middleware.spec.ts
+++ b/src/common/middleware/request-id.middleware.spec.ts
@@ -1,0 +1,53 @@
+import { Request, Response } from 'express';
+import { RequestIdMiddleware } from './request-id.middleware';
+import { getRequestId } from '../request-context/request-context.storage';
+
+describe('RequestIdMiddleware', () => {
+  let middleware: RequestIdMiddleware;
+  let mockRequest: Partial<Request>;
+  let mockResponse: Partial<Response>;
+  let next: jest.Mock;
+
+  beforeEach(() => {
+    middleware = new RequestIdMiddleware();
+    mockRequest = { headers: {} };
+    mockResponse = {
+      setHeader: jest.fn(),
+    };
+    next = jest.fn();
+  });
+
+  it('generates a request ID when the client does not send one', () => {
+    middleware.use(mockRequest as Request, mockResponse as Response, next);
+
+    const requestId = mockRequest.headers?.['x-request-id'] as string;
+    expect(requestId).toBeDefined();
+    expect(requestId).toHaveLength(36);
+    expect(mockResponse.setHeader).toHaveBeenCalledWith(
+      'X-Request-Id',
+      requestId,
+    );
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('respects a client-provided X-Request-Id header', () => {
+    mockRequest.headers = { 'x-request-id': 'client-provided-id' };
+
+    middleware.use(mockRequest as Request, mockResponse as Response, next);
+
+    expect(mockRequest.headers['x-request-id']).toBe('client-provided-id');
+    expect(mockResponse.setHeader).toHaveBeenCalledWith(
+      'X-Request-Id',
+      'client-provided-id',
+    );
+  });
+
+  it('stores the request ID in async context for downstream handlers', (done) => {
+    next.mockImplementation(() => {
+      expect(getRequestId()).toBe(mockRequest.headers?.['x-request-id']);
+      done();
+    });
+
+    middleware.use(mockRequest as Request, mockResponse as Response, next);
+  });
+});

--- a/src/common/middleware/request-id.middleware.ts
+++ b/src/common/middleware/request-id.middleware.ts
@@ -1,0 +1,22 @@
+import { Injectable, NestMiddleware } from '@nestjs/common';
+import { NextFunction, Request, Response } from 'express';
+import { randomUUID } from 'node:crypto';
+import { runWithRequestContext } from '../request-context/request-context.storage';
+
+export const REQUEST_ID_HEADER = 'x-request-id';
+
+@Injectable()
+export class RequestIdMiddleware implements NestMiddleware {
+  use(req: Request, res: Response, next: NextFunction): void {
+    const incoming = req.headers[REQUEST_ID_HEADER];
+    const requestId =
+      typeof incoming === 'string' && incoming.trim().length > 0
+        ? incoming.trim()
+        : randomUUID();
+
+    req.headers[REQUEST_ID_HEADER] = requestId;
+    res.setHeader('X-Request-Id', requestId);
+
+    runWithRequestContext({ requestId }, () => next());
+  }
+}

--- a/src/common/request-context/request-context.storage.ts
+++ b/src/common/request-context/request-context.storage.ts
@@ -1,0 +1,18 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+export interface RequestContext {
+  requestId: string;
+}
+
+const asyncLocalStorage = new AsyncLocalStorage<RequestContext>();
+
+export function runWithRequestContext<T>(
+  context: RequestContext,
+  callback: () => T,
+): T {
+  return asyncLocalStorage.run(context, callback);
+}
+
+export function getRequestId(): string | undefined {
+  return asyncLocalStorage.getStore()?.requestId;
+}

--- a/src/exception/globalException.filter.spec.ts
+++ b/src/exception/globalException.filter.spec.ts
@@ -2,7 +2,6 @@ import { GlobalExceptionFilter } from './globalException.filter';
 import { HttpException, HttpStatus } from '@nestjs/common';
 import { ArgumentsHost, HttpArgumentsHost } from '@nestjs/common/interfaces';
 import { Request, Response } from 'express';
-import { Test } from '@nestjs/testing';
 
 describe('GlobalExceptionFilter', () => {
   let filter: GlobalExceptionFilter;
@@ -15,10 +14,12 @@ describe('GlobalExceptionFilter', () => {
     mockResponse = {
       status: jest.fn().mockReturnThis(),
       json: jest.fn().mockReturnThis(),
+      setHeader: jest.fn(),
     };
     mockRequest = {
       method: 'GET',
       url: '/api/test',
+      headers: {},
     };
     const mockHttpContext: Partial<HttpArgumentsHost> = {
       getResponse: <T = any>() => mockResponse as unknown as T,
@@ -63,6 +64,22 @@ describe('GlobalExceptionFilter', () => {
       }),
     );
     expect(mockResponse.json).toHaveBeenCalledTimes(1);
+  });
+
+  it('should include requestId in error response when present on the request', () => {
+    mockRequest.headers = { 'x-request-id': 'error-request-id' };
+    const exception = new HttpException('Not found', HttpStatus.NOT_FOUND);
+    filter.catch(exception, mockHost);
+
+    expect(mockResponse.setHeader).toHaveBeenCalledWith(
+      'X-Request-Id',
+      'error-request-id',
+    );
+    expect(mockResponse.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requestId: 'error-request-id',
+      }),
+    );
   });
 
   it('should handle unknown exception correctly', () => {

--- a/src/exception/globalException.filter.ts
+++ b/src/exception/globalException.filter.ts
@@ -6,6 +6,8 @@ import {
   HttpStatus,
 } from '@nestjs/common';
 import { Request, Response } from 'express';
+import { REQUEST_ID_HEADER } from '../common/middleware/request-id.middleware';
+import { getRequestId } from '../common/request-context/request-context.storage';
 import { AppLogger } from '../logger/app-logger.service';
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -77,6 +79,16 @@ export class GlobalExceptionFilter implements ExceptionFilter {
       GlobalExceptionFilter.name,
     );
 
+    const requestId =
+      getRequestId() ??
+      (typeof request.headers[REQUEST_ID_HEADER] === 'string'
+        ? request.headers[REQUEST_ID_HEADER]
+        : undefined);
+
+    if (requestId) {
+      response.setHeader('X-Request-Id', requestId);
+    }
+
     const body: Record<string, unknown> = {
       statusCode: status,
       message,
@@ -85,6 +97,7 @@ export class GlobalExceptionFilter implements ExceptionFilter {
       error,
     };
     if (code) body.code = code;
+    if (requestId) body.requestId = requestId;
 
     response.status(status).json(body);
   }

--- a/src/logger/app-logger.service.spec.ts
+++ b/src/logger/app-logger.service.spec.ts
@@ -1,0 +1,38 @@
+import { AppLogger } from './app-logger.service';
+import winstonLogger from './app-logger.service';
+import { runWithRequestContext } from '../common/request-context/request-context.storage';
+
+describe('AppLogger', () => {
+  let logger: AppLogger;
+
+  beforeEach(() => {
+    logger = new AppLogger();
+  });
+
+  it('includes requestId in log metadata when request context is set', () => {
+    const infoSpy = jest.spyOn(winstonLogger, 'info');
+
+    runWithRequestContext({ requestId: 'test-request-id' }, () => {
+      logger.log('hello', 'TestContext');
+    });
+
+    expect(infoSpy).toHaveBeenCalledWith('hello', {
+      context: 'TestContext',
+      requestId: 'test-request-id',
+    });
+
+    infoSpy.mockRestore();
+  });
+
+  it('omits requestId when no request context is set', () => {
+    const infoSpy = jest.spyOn(winstonLogger, 'info');
+
+    logger.log('hello', 'TestContext');
+
+    expect(infoSpy).toHaveBeenCalledWith('hello', {
+      context: 'TestContext',
+    });
+
+    infoSpy.mockRestore();
+  });
+});

--- a/src/logger/app-logger.service.ts
+++ b/src/logger/app-logger.service.ts
@@ -9,6 +9,7 @@ import {
   transports,
   Logger as WinstonLogger,
 } from 'winston';
+import { getRequestId } from '../common/request-context/request-context.storage';
 
 const isProduction = process.env.NODE_ENV === 'production';
 
@@ -19,29 +20,49 @@ const winstonLogger: WinstonLogger = createLogger({
     : format.combine(
         format.colorize(),
         format.timestamp(),
-        format.printf(({ timestamp, level, message, context, ...meta }) => {
-          return `${timestamp} [${level}]${context ? ' [' + context + ']' : ''}: ${message} ${Object.keys(meta).length ? JSON.stringify(meta) : ''}`;
+        format.printf((info) => {
+          const { timestamp, level, message, context, requestId, ...meta } =
+            info;
+          const requestIdPart =
+            typeof requestId === 'string' ? ` [${requestId}]` : '';
+          const contextPart =
+            typeof context === 'string' ? ` [${context}]` : '';
+          const metaSuffix =
+            Object.keys(meta).length > 0 ? ` ${JSON.stringify(meta)}` : '';
+          return `${String(timestamp)} [${String(level)}]${contextPart}${requestIdPart}: ${String(message)}${metaSuffix}`;
         }),
       ),
   transports: [new transports.Console()],
 });
 
+function buildMeta(
+  context?: string,
+  extra?: Record<string, unknown>,
+): Record<string, unknown> {
+  const requestId = getRequestId();
+  return {
+    ...(context ? { context } : {}),
+    ...(requestId ? { requestId } : {}),
+    ...extra,
+  };
+}
+
 @Injectable()
 export class AppLogger implements NestLoggerService {
   log(message: any, context?: string) {
-    winstonLogger.info(message, { context });
+    winstonLogger.info(message, buildMeta(context));
   }
   error(message: any, trace?: string, context?: string) {
-    winstonLogger.error(message, { trace, context });
+    winstonLogger.error(message, buildMeta(context, { trace }));
   }
   warn(message: any, context?: string) {
-    winstonLogger.warn(message, { context });
+    winstonLogger.warn(message, buildMeta(context));
   }
   debug?(message: any, context?: string) {
-    winstonLogger.debug(message, { context });
+    winstonLogger.debug(message, buildMeta(context));
   }
   verbose?(message: any, context?: string) {
-    winstonLogger.verbose(message, { context });
+    winstonLogger.verbose(message, buildMeta(context));
   }
   setLogLevels?(levels: LogLevel[]) {
     winstonLogger.level = levels[0];


### PR DESCRIPTION
- Add RequestIdMiddleware to generate or propagate X-Request-Id
- Store request ID in AsyncLocalStorage for request-scoped logging
- Include requestId in AppLogger output and error response bodies
- Document correlation ID behavior in docs/logging-monitoring.md
close #15