### PR TITLE
feat: validate environment configuration on startup (Closes #12)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,13 +7,18 @@ DB_HOST=localhost
 DB_PORT=5432
 DB_USERNAME=postgres
 DB_PASSWORD=postgres
-DB_DATABASE=myfans
+DB_NAME=my_fans_db
 
 # ─── JWT ─────────────────────────────────────────────
-JWT_ACCESS_SECRET=change-me-access-secret
+# Required: set JWT_SECRET (or JWT_ACCESS_SECRET) and JWT_EXPIRES_IN (or JWT_ACCESS_EXPIRATION)
+JWT_SECRET=change-me-jwt-secret
+JWT_EXPIRES_IN=15m
 JWT_REFRESH_SECRET=change-me-refresh-secret
-JWT_ACCESS_EXPIRATION=15m
 JWT_REFRESH_EXPIRATION=7d
+
+# Optional aliases used by some auth modules
+# JWT_ACCESS_SECRET=change-me-access-secret
+# JWT_ACCESS_EXPIRATION=15m
 
 # ─── Rate Limiting ───────────────────────────────────
 # Set to "false" to disable all rate limiting (not recommended for production)

--- a/README.md
+++ b/README.md
@@ -112,14 +112,22 @@ curl -X DELETE http://localhost:3000/users/1
    ```
 
 3. **Configure Environment**:
-   Create a `.env` file in the root directory with the following:
-   ```env
-   DB_HOST=localhost
-   DB_PORT=5432
-   DB_NAME=my_fans_db
-   DB_USERNAME=postgres
-   DB_PASSWORD=password
+   Copy the example file and adjust values for your local PostgreSQL instance:
+   ```bash
+   cp .env.example .env
    ```
+
+   Required variables (see `.env.example` for the full list):
+
+   | Variable | Description |
+   |----------|-------------|
+   | `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USERNAME`, `DB_PASSWORD` | PostgreSQL connection |
+   | `JWT_SECRET` (or `JWT_ACCESS_SECRET`) | Access-token signing secret |
+   | `JWT_EXPIRES_IN` (or `JWT_ACCESS_EXPIRATION`) | Access-token lifetime |
+   | `PORT` | HTTP server port (default `3000`) |
+   | `NODE_ENV` | `development`, `test`, or `production` |
+
+   The app validates environment variables at startup and exits with a readable error if required values are missing or invalid.
 
 4. **Start the Application**:
    ```bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.2",
         "dotenv": "^16.5.0",
+        "joi": "^18.2.3",
         "passport": "^0.7.0",
         "passport-jwt": "^4.0.1",
         "pg": "^8.16.0",
@@ -1008,6 +1009,54 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/@hapi/address": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-5.1.1.tgz",
+      "integrity": "sha512-A+po2d/dVoY7cYajycYI43ZbYMXukuopIsqCjh5QzsBCipDtdofHntljDlpccMjIfTy6UOkg+5KPriwYch2bXA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^11.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@hapi/formula": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-3.0.2.tgz",
+      "integrity": "sha512-hY5YPNXzw1He7s0iqkRQi+uMGh383CGdyyIGYtB+W5N3KHPXoqychklvHhKCC9M3Xtv0OCs/IHw+r4dcHtBYWw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@hapi/hoek": {
+      "version": "11.0.7",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.7.tgz",
+      "integrity": "sha512-HV5undWkKzcB4RZUusqOpcgxOaq6VOAH7zhhIr2g3G8NF/MlFO75SjOr2NfuSx0Mh40+1FqCkagKLJRykUWoFQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@hapi/pinpoint": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-2.0.1.tgz",
+      "integrity": "sha512-EKQmr16tM8s16vTT3cA5L0kZZcTMU5DUOZTuvpnY738m+jyP3JIUj+Mm1xc1rsLkGBQ/gVnfKYPwOmPg1tUR4Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@hapi/tlds": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@hapi/tlds/-/tlds-1.1.7.tgz",
+      "integrity": "sha512-MgNjRwy9Ti92yVAixLmDc8dd1bJIKwO9qlWCfFQRwRmUEDPQHYn4G6hwPFvFGUTzAa0FsS+inMjLin7GnyBRhA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@hapi/topo": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-6.0.2.tgz",
+      "integrity": "sha512-KR3rD5inZbGMrHmgPxsJ9dbi6zEK+C3ZwUwTa+eMwWLz7oijWUTWD2pMSNNYJAU6Qq+65NkxXjqHr/7LM2Xkqg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^11.0.2"
       }
     },
     "node_modules/@humanfs/core": {
@@ -3315,6 +3364,12 @@
       "integrity": "sha512-Uy0+khmZqUrUGm5dmMqVlnvufZRSK0FbYzVgp0UMstm+F5+W2/jnEEQyc9vo1ZR/E5ZI/B1WjjoTqBqwJL6Krw==",
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
     "node_modules/@swc/cli": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@swc/cli/-/cli-0.6.0.tgz",
@@ -3390,7 +3445,7 @@
       "version": "1.15.41",
       "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.41.tgz",
       "integrity": "sha512-03nQq/082QRJJiOvp3FGbgxTGyyxMxohPTjhk/W9bD2J0tk4ukITI7goOhOO2WbaHn/lsPmo/zf8+DIXhwpgYQ==",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3434,6 +3489,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3450,6 +3506,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3466,6 +3523,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3482,6 +3540,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3498,6 +3557,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3514,6 +3574,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3530,6 +3591,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3546,6 +3608,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3562,6 +3625,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3578,6 +3642,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3594,6 +3659,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3610,6 +3676,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3623,14 +3690,14 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
       "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@swc/types": {
       "version": "0.1.27",
       "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.27.tgz",
       "integrity": "sha512-K6h3iUlqeM946U4sXFYeahefR1YBbXJvko+hv8WS8/0BNJ4OHiHRywMnQUJCqkR7Y9+hqQ1TvEpiKqUhz7NEFg==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/counter": "^0.1.3"
@@ -9772,6 +9839,24 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/joi": {
+      "version": "18.2.3",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-18.2.3.tgz",
+      "integrity": "sha512-N5A3KTWQpPWT4ExxxPlUx7WmykGXRzhNidWhV41d6Abu9YfI2NyWCJuxdPnslJCPWtbRpSVOWSnSS6GakLM/Rg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/address": "^5.1.1",
+        "@hapi/formula": "^3.0.2",
+        "@hapi/hoek": "^11.0.7",
+        "@hapi/pinpoint": "^2.0.1",
+        "@hapi/tlds": "^1.1.1",
+        "@hapi/topo": "^6.0.2",
+        "@standard-schema/spec": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/js-tokens": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.2",
     "dotenv": "^16.5.0",
+    "joi": "^18.2.3",
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",
     "pg": "^8.16.0",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -9,6 +9,7 @@ import { PostsModule } from './posts/posts.module';
 import { NotificationsModule } from './notifications/notifications.module';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ConfigModule, ConfigService } from '@nestjs/config';
+import { validateEnv } from './config/env.validation';
 import { CacheModule } from '@nestjs/cache-manager';
 import { dataOption } from './migrations/appDataSource.db';
 import { LoggerModule } from './logger/logger.module';
@@ -20,7 +21,7 @@ import { AdminModule } from './admin/admin.module';
 
 @Module({
   imports: [
-    ConfigModule.forRoot({ isGlobal: true }),
+    ConfigModule.forRoot({ isGlobal: true, validate: validateEnv }),
     CacheModule.register({
       isGlobal: true,
       ttl: 60000, // 60 seconds default TTL

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -1,0 +1,44 @@
+import { ConfigService } from '@nestjs/config';
+
+export interface DatabaseConfig {
+  host: string;
+  port: number;
+  username: string;
+  password: string;
+  name: string;
+}
+
+export interface JwtConfig {
+  accessSecret: string;
+  refreshSecret: string;
+  accessExpiresIn: string;
+  refreshExpiresIn: string;
+}
+
+export function getDatabaseConfig(
+  configService: ConfigService,
+): DatabaseConfig {
+  return {
+    host: configService.getOrThrow<string>('DB_HOST'),
+    port: configService.getOrThrow<number>('DB_PORT'),
+    username: configService.getOrThrow<string>('DB_USERNAME'),
+    password: configService.getOrThrow<string>('DB_PASSWORD'),
+    name: configService.getOrThrow<string>('DB_NAME'),
+  };
+}
+
+export function getJwtConfig(configService: ConfigService): JwtConfig {
+  return {
+    accessSecret:
+      configService.get<string>('JWT_ACCESS_SECRET') ??
+      configService.getOrThrow<string>('JWT_SECRET'),
+    refreshSecret:
+      configService.get<string>('JWT_REFRESH_SECRET') ??
+      'fallback-refresh-secret',
+    accessExpiresIn:
+      configService.get<string>('JWT_ACCESS_EXPIRATION') ??
+      configService.getOrThrow<string>('JWT_EXPIRES_IN'),
+    refreshExpiresIn:
+      configService.get<string>('JWT_REFRESH_EXPIRATION') ?? '7d',
+  };
+}

--- a/src/config/env.validation.spec.ts
+++ b/src/config/env.validation.spec.ts
@@ -1,0 +1,92 @@
+import { validateEnv } from './env.validation';
+
+describe('validateEnv', () => {
+  const validConfig = {
+    NODE_ENV: 'development',
+    PORT: '3000',
+    DB_HOST: 'localhost',
+    DB_PORT: '5432',
+    DB_NAME: 'my_fans_db',
+    DB_USERNAME: 'postgres',
+    DB_PASSWORD: 'postgres',
+    JWT_SECRET: 'test-secret',
+    JWT_EXPIRES_IN: '1h',
+  };
+
+  it('accepts a valid configuration', () => {
+    expect(() => validateEnv(validConfig)).not.toThrow();
+  });
+
+  it('accepts JWT_ACCESS_SECRET and JWT_ACCESS_EXPIRATION aliases', () => {
+    expect(() =>
+      validateEnv({
+        NODE_ENV: 'development',
+        PORT: '3000',
+        DB_HOST: 'localhost',
+        DB_PORT: '5432',
+        DB_NAME: 'my_fans_db',
+        DB_USERNAME: 'postgres',
+        DB_PASSWORD: 'postgres',
+        JWT_ACCESS_SECRET: 'access-secret',
+        JWT_ACCESS_EXPIRATION: '15m',
+      }),
+    ).not.toThrow();
+  });
+
+  it('rejects missing JWT secret', () => {
+    expect(() =>
+      validateEnv({
+        NODE_ENV: 'development',
+        PORT: '3000',
+        DB_HOST: 'localhost',
+        DB_PORT: '5432',
+        DB_NAME: 'my_fans_db',
+        DB_USERNAME: 'postgres',
+        DB_PASSWORD: 'postgres',
+        JWT_EXPIRES_IN: '1h',
+      }),
+    ).toThrow(/JWT_SECRET or JWT_ACCESS_SECRET is required/);
+  });
+
+  it('rejects missing JWT expiration', () => {
+    expect(() =>
+      validateEnv({
+        NODE_ENV: 'development',
+        PORT: '3000',
+        DB_HOST: 'localhost',
+        DB_PORT: '5432',
+        DB_NAME: 'my_fans_db',
+        DB_USERNAME: 'postgres',
+        DB_PASSWORD: 'postgres',
+        JWT_SECRET: 'test-secret',
+      }),
+    ).toThrow(/JWT_EXPIRES_IN or JWT_ACCESS_EXPIRATION is required/);
+  });
+
+  it('rejects missing database credentials', () => {
+    expect(() =>
+      validateEnv({
+        NODE_ENV: 'development',
+        PORT: '3000',
+        DB_HOST: 'localhost',
+        DB_PORT: '5432',
+        DB_NAME: 'my_fans_db',
+        DB_USERNAME: 'postgres',
+        JWT_SECRET: 'test-secret',
+        JWT_EXPIRES_IN: '1h',
+      }),
+    ).toThrow(/DB_PASSWORD/);
+  });
+
+  it('rejects invalid PORT values', () => {
+    expect(() => validateEnv({ ...validConfig, PORT: 'not-a-port' })).toThrow(
+      /PORT/,
+    );
+  });
+
+  it('rejects invalid DB_PORT values', () => {
+    expect(() =>
+      validateEnv({ ...validConfig, DB_PORT: 'not-a-port' }),
+    ).toThrow(/DB_PORT/);
+  });
+});

--- a/src/config/env.validation.ts
+++ b/src/config/env.validation.ts
@@ -1,0 +1,59 @@
+import * as Joi from 'joi';
+
+const envSchema = Joi.object({
+  NODE_ENV: Joi.string()
+    .valid('development', 'production', 'test')
+    .default('development'),
+  PORT: Joi.number().port().default(3000),
+  DB_HOST: Joi.string().required(),
+  DB_PORT: Joi.number().port().required(),
+  DB_NAME: Joi.string().required(),
+  DB_USERNAME: Joi.string().required(),
+  DB_PASSWORD: Joi.string().required(),
+  JWT_SECRET: Joi.string().min(1).optional(),
+  JWT_ACCESS_SECRET: Joi.string().min(1).optional(),
+  JWT_EXPIRES_IN: Joi.string().min(1).optional(),
+  JWT_ACCESS_EXPIRATION: Joi.string().min(1).optional(),
+  JWT_REFRESH_SECRET: Joi.string().min(1).optional(),
+  JWT_REFRESH_EXPIRATION: Joi.string().min(1).optional(),
+});
+
+function assertJwtConfig(value: Record<string, unknown>): void {
+  const errors: string[] = [];
+
+  if (!value.JWT_SECRET && !value.JWT_ACCESS_SECRET) {
+    errors.push('JWT_SECRET or JWT_ACCESS_SECRET is required');
+  }
+
+  if (!value.JWT_EXPIRES_IN && !value.JWT_ACCESS_EXPIRATION) {
+    errors.push('JWT_EXPIRES_IN or JWT_ACCESS_EXPIRATION is required');
+  }
+
+  if (errors.length > 0) {
+    throw new Error(
+      `Environment validation failed:\n${errors.map((message) => `  - ${message}`).join('\n')}`,
+    );
+  }
+}
+
+export function validateEnv(
+  config: Record<string, unknown>,
+): Record<string, unknown> {
+  const result = envSchema.validate(config, {
+    allowUnknown: true,
+    abortEarly: false,
+    convert: true,
+  });
+
+  if (result.error) {
+    const details = result.error.details.map(
+      (detail) => `  - ${detail.message}`,
+    );
+    throw new Error(`Environment validation failed:\n${details.join('\n')}`);
+  }
+
+  const value = result.value as Record<string, unknown>;
+  assertJwtConfig(value);
+
+  return value;
+}


### PR DESCRIPTION
- Add Joi-based env.validation.ts wired into ConfigModule.forRoot
- Add typed ConfigService helpers for database and JWT settings
- Align .env.example with required DB_*, JWT_*, PORT, and NODE_ENV vars
- Update README setup section to reference .env.example

close #12