### PR TITLE
 feat: add avatar upload service with pluggable storage adapter

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,3 +41,14 @@ THROTTLE_LONG_LIMIT=3600
 
 # Proxy trust — set "true" when behind a reverse proxy so X-Forwarded-For is honored
 TRUST_PROXY=false
+
+# ─── Avatar / File Uploads ────────────────────────────
+# Storage driver: "local" (default) or "s3"
+STORAGE_DRIVER=local
+
+# Root directory for locally stored uploads (relative to project root)
+UPLOAD_DIR=./uploads
+
+# Public base URL used to build avatarUrl in API responses
+# For local dev this should match your server's host + port
+PUBLIC_BASE_URL=http://localhost:3000

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,7 @@
         "@testcontainers/postgresql": "^12.0.3",
         "@types/express": "^5.0.0",
         "@types/jest": "^29.5.14",
+        "@types/multer": "^2.1.0",
         "@types/node": "^22.10.7",
         "@types/supertest": "^6.0.2",
         "eslint": "^9.18.0",
@@ -3960,6 +3961,16 @@
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
       "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
+    },
+    "node_modules/@types/multer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/multer/-/multer-2.1.0.tgz",
+      "integrity": "sha512-zYZb0+nJhOHtPpGDb3vqPjwpdeGlGC157VpkqNQL+UU2qwoacoQ7MpsAmUptI/0Oa127X32JzWDqQVEXp2RcIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*"
+      }
     },
     "node_modules/@types/node": {
       "version": "22.19.21",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "@testcontainers/postgresql": "^12.0.3",
     "@types/express": "^5.0.0",
     "@types/jest": "^29.5.14",
+    "@types/multer": "^2.1.0",
     "@types/node": "^22.10.7",
     "@types/supertest": "^6.0.2",
     "eslint": "^9.18.0",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -17,6 +17,7 @@ import { HealthModule } from './monitoring/health.module';
 import { ThrottleConfigModule } from './common/throttle/throttle.module';
 import { AuditModule } from './audit/audit.module';
 import { AdminModule } from './admin/admin.module';
+import { UploadsModule } from './uploads/uploads.module';
 
 @Module({
   imports: [
@@ -44,6 +45,7 @@ import { AdminModule } from './admin/admin.module';
     NotificationsModule,
     AuditModule,
     AdminModule,
+    UploadsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,15 +1,21 @@
 import { NestFactory } from '@nestjs/core';
+import { NestExpressApplication } from '@nestjs/platform-express';
 import { AppModule } from './app.module';
 import { GlobalExceptionFilter } from './exception/globalException.filter';
 import { AppLogger } from './logger/app-logger.service';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { ValidationPipe } from '@nestjs/common';
+import * as path from 'path';
 
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule, {
+  const app = await NestFactory.create<NestExpressApplication>(AppModule, {
     bufferLogs: true,
     logger: new AppLogger(),
   });
+
+  // Serve uploaded files (local storage only — S3 serves its own URLs)
+  const uploadDir = path.resolve(process.env.UPLOAD_DIR ?? './uploads');
+  app.useStaticAssets(uploadDir, { prefix: '/uploads' });
 
   // Global validation pipe
   app.useGlobalPipes(

--- a/src/uploads/adapters/local-storage.adapter.ts
+++ b/src/uploads/adapters/local-storage.adapter.ts
@@ -1,0 +1,37 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import { StorageAdapter } from './storage-adapter.interface';
+
+@Injectable()
+export class LocalStorageAdapter implements StorageAdapter {
+  private readonly uploadDir: string;
+  private readonly baseUrl: string;
+
+  constructor(private readonly config: ConfigService) {
+    this.uploadDir = path.join(
+      config.get<string>('UPLOAD_DIR', './uploads'),
+      'avatars',
+    );
+    this.baseUrl = config.get<string>(
+      'PUBLIC_BASE_URL',
+      'http://localhost:3000',
+    );
+  }
+
+  async save(buffer: Buffer, filename: string): Promise<string> {
+    await fs.mkdir(this.uploadDir, { recursive: true });
+    await fs.writeFile(path.join(this.uploadDir, filename), buffer);
+    return `${this.baseUrl}/uploads/avatars/${filename}`;
+  }
+
+  async delete(url: string): Promise<void> {
+    try {
+      const filename = path.basename(url);
+      await fs.unlink(path.join(this.uploadDir, filename));
+    } catch {
+      // Ignore — file may already be gone
+    }
+  }
+}

--- a/src/uploads/adapters/s3-storage.adapter.ts
+++ b/src/uploads/adapters/s3-storage.adapter.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@nestjs/common';
+import { StorageAdapter } from './storage-adapter.interface';
+
+// Stub — wire up an S3 SDK (e.g. @aws-sdk/client-s3) and set
+// AWS_BUCKET, AWS_REGION, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY
+// then set STORAGE_DRIVER=s3 in your environment.
+@Injectable()
+export class S3StorageAdapter implements StorageAdapter {
+  async save(_buffer: Buffer, _filename: string): Promise<string> {
+    throw new Error('S3StorageAdapter is not yet implemented');
+  }
+
+  async delete(_url: string): Promise<void> {
+    throw new Error('S3StorageAdapter is not yet implemented');
+  }
+}

--- a/src/uploads/adapters/storage-adapter.interface.ts
+++ b/src/uploads/adapters/storage-adapter.interface.ts
@@ -1,0 +1,6 @@
+export const STORAGE_ADAPTER = Symbol('STORAGE_ADAPTER');
+
+export interface StorageAdapter {
+  save(buffer: Buffer, filename: string): Promise<string>;
+  delete(url: string): Promise<void>;
+}

--- a/src/uploads/avatar-upload.controller.spec.ts
+++ b/src/uploads/avatar-upload.controller.spec.ts
@@ -1,0 +1,56 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AvatarUploadController } from './avatar-upload.controller';
+import { AvatarUploadService } from './avatar-upload.service';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+
+const mockFile = (): Express.Multer.File =>
+  ({
+    fieldname: 'avatar',
+    originalname: 'photo.jpg',
+    encoding: '7bit',
+    mimetype: 'image/jpeg',
+    size: 1024,
+    buffer: Buffer.from('fake-image-data'),
+  }) as Express.Multer.File;
+
+describe('AvatarUploadController', () => {
+  let controller: AvatarUploadController;
+  let service: jest.Mocked<Pick<AvatarUploadService, 'uploadAvatar'>>;
+
+  const AVATAR_URL = 'http://localhost:3000/uploads/avatars/uuid.jpg';
+
+  beforeEach(async () => {
+    service = {
+      uploadAvatar: jest.fn().mockResolvedValue({ avatarUrl: AVATAR_URL }),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AvatarUploadController],
+      providers: [{ provide: AvatarUploadService, useValue: service }],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+
+    controller = module.get<AvatarUploadController>(AvatarUploadController);
+  });
+
+  it('is defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  it('delegates to AvatarUploadService with the authenticated userId', async () => {
+    const currentUser = { userId: 42, email: 'test@example.com', role: 'fan' };
+    await controller.uploadAvatar(currentUser, mockFile());
+    expect(service.uploadAvatar).toHaveBeenCalledWith(42, expect.any(Object));
+  });
+
+  it('returns avatarUrl and success message', async () => {
+    const currentUser = { userId: 1, email: 'test@example.com', role: 'fan' };
+    const result = await controller.uploadAvatar(currentUser, mockFile());
+    expect(result).toEqual({
+      avatarUrl: AVATAR_URL,
+      message: 'Avatar uploaded successfully',
+    });
+  });
+});

--- a/src/uploads/avatar-upload.controller.ts
+++ b/src/uploads/avatar-upload.controller.ts
@@ -1,0 +1,80 @@
+import {
+  Controller,
+  FileTypeValidator,
+  MaxFileSizeValidator,
+  ParseFilePipe,
+  Post,
+  UploadedFile,
+  UseGuards,
+  UseInterceptors,
+} from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
+import { memoryStorage } from 'multer';
+import {
+  ApiBearerAuth,
+  ApiBody,
+  ApiConsumes,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import { AvatarUploadService } from './avatar-upload.service';
+import { AvatarUploadResponseDto } from './dto/avatar-upload-response.dto';
+
+@ApiTags('Uploads')
+@ApiBearerAuth('JWT-auth')
+@Controller('users/me')
+export class AvatarUploadController {
+  constructor(private readonly avatarUploadService: AvatarUploadService) {}
+
+  @Post('avatar')
+  @UseGuards(JwtAuthGuard)
+  @UseInterceptors(FileInterceptor('avatar', { storage: memoryStorage() }))
+  @ApiOperation({ summary: 'Upload or replace your avatar image (JWT required)' })
+  @ApiConsumes('multipart/form-data')
+  @ApiBody({
+    schema: {
+      type: 'object',
+      required: ['avatar'],
+      properties: {
+        avatar: {
+          type: 'string',
+          format: 'binary',
+          description: 'Image file — JPEG, PNG, or WebP; max 2 MB',
+        },
+      },
+    },
+  })
+  @ApiResponse({
+    status: 201,
+    description: 'Avatar uploaded and profile updated',
+    type: AvatarUploadResponseDto,
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Invalid file type or file exceeds 2 MB size limit',
+  })
+  @ApiUnauthorizedResponse({ description: 'JWT token missing or invalid' })
+  async uploadAvatar(
+    @CurrentUser() currentUser: { userId: number },
+    @UploadedFile(
+      new ParseFilePipe({
+        validators: [
+          new MaxFileSizeValidator({ maxSize: 2 * 1024 * 1024 }),
+          new FileTypeValidator({ fileType: /^image\/(jpeg|png|webp)$/ }),
+        ],
+        errorHttpStatusCode: 400,
+      }),
+    )
+    file: Express.Multer.File,
+  ): Promise<AvatarUploadResponseDto> {
+    const { avatarUrl } = await this.avatarUploadService.uploadAvatar(
+      currentUser.userId,
+      file,
+    );
+    return { avatarUrl, message: 'Avatar uploaded successfully' };
+  }
+}

--- a/src/uploads/avatar-upload.controller.ts
+++ b/src/uploads/avatar-upload.controller.ts
@@ -33,7 +33,9 @@ export class AvatarUploadController {
   @Post('avatar')
   @UseGuards(JwtAuthGuard)
   @UseInterceptors(FileInterceptor('avatar', { storage: memoryStorage() }))
-  @ApiOperation({ summary: 'Upload or replace your avatar image (JWT required)' })
+  @ApiOperation({
+    summary: 'Upload or replace your avatar image (JWT required)',
+  })
   @ApiConsumes('multipart/form-data')
   @ApiBody({
     schema: {

--- a/src/uploads/avatar-upload.service.spec.ts
+++ b/src/uploads/avatar-upload.service.spec.ts
@@ -1,7 +1,10 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { BadRequestException } from '@nestjs/common';
 import { AvatarUploadService } from './avatar-upload.service';
-import { STORAGE_ADAPTER, StorageAdapter } from './adapters/storage-adapter.interface';
+import {
+  STORAGE_ADAPTER,
+  StorageAdapter,
+} from './adapters/storage-adapter.interface';
 import { NoOpVirusScanHook } from './hooks/virus-scan.hook';
 import { UsersService } from '../users/users.service';
 import { User } from '../users/user.entity';
@@ -49,7 +52,9 @@ describe('AvatarUploadService', () => {
       updateProfile: jest.fn().mockResolvedValue(undefined),
     };
 
-    virusScan = { scan: jest.fn().mockResolvedValue(undefined) } as jest.Mocked<NoOpVirusScanHook>;
+    virusScan = {
+      scan: jest.fn().mockResolvedValue(undefined),
+    } as jest.Mocked<NoOpVirusScanHook>;
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -116,9 +121,7 @@ describe('AvatarUploadService', () => {
 
       const [, savedFilename] = storage.save.mock.calls[0];
       expect(savedFilename).not.toContain('photo');
-      expect(savedFilename).toMatch(
-        /^[0-9a-f-]{36}\.(jpg|png|webp)$/,
-      );
+      expect(savedFilename).toMatch(/^[0-9a-f-]{36}\.(jpg|png|webp)$/);
     });
 
     it('calls the virus scan hook before saving', async () => {

--- a/src/uploads/avatar-upload.service.spec.ts
+++ b/src/uploads/avatar-upload.service.spec.ts
@@ -1,0 +1,156 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException } from '@nestjs/common';
+import { AvatarUploadService } from './avatar-upload.service';
+import { STORAGE_ADAPTER, StorageAdapter } from './adapters/storage-adapter.interface';
+import { NoOpVirusScanHook } from './hooks/virus-scan.hook';
+import { UsersService } from '../users/users.service';
+import { User } from '../users/user.entity';
+
+const makeFile = (
+  overrides: Partial<Express.Multer.File> = {},
+): Express.Multer.File =>
+  ({
+    fieldname: 'avatar',
+    originalname: 'photo.jpg',
+    encoding: '7bit',
+    mimetype: 'image/jpeg',
+    size: 1024,
+    buffer: Buffer.from('fake-image-data'),
+    stream: null as never,
+    destination: '',
+    filename: '',
+    path: '',
+    ...overrides,
+  }) as Express.Multer.File;
+
+const mockUser = (avatarUrl: string | null = null): Partial<User> => ({
+  id: 1,
+  name: 'Test User',
+  email: 'test@example.com',
+  avatarUrl,
+});
+
+describe('AvatarUploadService', () => {
+  let service: AvatarUploadService;
+  let storage: jest.Mocked<StorageAdapter>;
+  let usersService: { findById: jest.Mock; updateProfile: jest.Mock };
+  let virusScan: jest.Mocked<NoOpVirusScanHook>;
+
+  const AVATAR_URL = 'http://localhost:3000/uploads/avatars/new-uuid.jpg';
+
+  beforeEach(async () => {
+    storage = {
+      save: jest.fn().mockResolvedValue(AVATAR_URL),
+      delete: jest.fn().mockResolvedValue(undefined),
+    };
+
+    usersService = {
+      findById: jest.fn().mockResolvedValue(mockUser()),
+      updateProfile: jest.fn().mockResolvedValue(undefined),
+    };
+
+    virusScan = { scan: jest.fn().mockResolvedValue(undefined) } as jest.Mocked<NoOpVirusScanHook>;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AvatarUploadService,
+        { provide: STORAGE_ADAPTER, useValue: storage },
+        { provide: UsersService, useValue: usersService },
+        { provide: NoOpVirusScanHook, useValue: virusScan },
+      ],
+    }).compile();
+
+    service = module.get<AvatarUploadService>(AvatarUploadService);
+  });
+
+  describe('uploadAvatar — validation', () => {
+    it('rejects unsupported MIME types with code INVALID_FILE_TYPE', async () => {
+      const file = makeFile({ mimetype: 'image/gif' });
+      await expect(service.uploadAvatar(1, file)).rejects.toMatchObject({
+        message: expect.stringContaining('File type not allowed'),
+        response: expect.objectContaining({ code: 'INVALID_FILE_TYPE' }),
+      });
+    });
+
+    it('rejects files exceeding 2 MB with code FILE_TOO_LARGE', async () => {
+      const file = makeFile({ size: 3 * 1024 * 1024 });
+      await expect(service.uploadAvatar(1, file)).rejects.toMatchObject({
+        message: expect.stringContaining('File too large'),
+        response: expect.objectContaining({ code: 'FILE_TOO_LARGE' }),
+      });
+    });
+
+    it('throws BadRequestException for invalid types', async () => {
+      await expect(
+        service.uploadAvatar(1, makeFile({ mimetype: 'application/pdf' })),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+  });
+
+  describe('uploadAvatar — happy path', () => {
+    it('returns the public avatarUrl on success', async () => {
+      const result = await service.uploadAvatar(1, makeFile());
+      expect(result).toEqual({ avatarUrl: AVATAR_URL });
+    });
+
+    it('does NOT delete old avatar when user has none', async () => {
+      usersService.findById.mockResolvedValue(mockUser(null) as User);
+      await service.uploadAvatar(1, makeFile());
+      expect(storage.delete).not.toHaveBeenCalled();
+    });
+
+    it('deletes old avatar file before saving the new one', async () => {
+      const OLD_URL = 'http://localhost:3000/uploads/avatars/old.jpg';
+      usersService.findById.mockResolvedValue(mockUser(OLD_URL) as User);
+
+      await service.uploadAvatar(1, makeFile());
+
+      expect(storage.delete).toHaveBeenCalledWith(OLD_URL);
+      const deleteOrder = storage.delete.mock.invocationCallOrder[0];
+      const saveOrder = storage.save.mock.invocationCallOrder[0];
+      expect(deleteOrder).toBeLessThan(saveOrder);
+    });
+
+    it('stores the file with a randomized UUID filename, not the original name', async () => {
+      await service.uploadAvatar(1, makeFile({ originalname: 'photo.jpg' }));
+
+      const [, savedFilename] = storage.save.mock.calls[0];
+      expect(savedFilename).not.toContain('photo');
+      expect(savedFilename).toMatch(
+        /^[0-9a-f-]{36}\.(jpg|png|webp)$/,
+      );
+    });
+
+    it('calls the virus scan hook before saving', async () => {
+      await service.uploadAvatar(1, makeFile());
+
+      const virusScanOrder = virusScan.scan.mock.invocationCallOrder[0];
+      const saveOrder = storage.save.mock.invocationCallOrder[0];
+      expect(virusScanOrder).toBeLessThan(saveOrder);
+    });
+
+    it('persists the new avatarUrl on the user profile', async () => {
+      await service.uploadAvatar(1, makeFile());
+      expect(usersService.updateProfile).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({ avatarUrl: AVATAR_URL }),
+      );
+    });
+
+    it('accepts PNG files and uses the .png extension', async () => {
+      storage.save.mockResolvedValue(
+        'http://localhost:3000/uploads/avatars/uuid.png',
+      );
+      await service.uploadAvatar(1, makeFile({ mimetype: 'image/png' }));
+
+      const [, filename] = storage.save.mock.calls[0];
+      expect(filename).toMatch(/\.png$/);
+    });
+
+    it('accepts WebP files and uses the .webp extension', async () => {
+      await service.uploadAvatar(1, makeFile({ mimetype: 'image/webp' }));
+      const [, filename] = storage.save.mock.calls[0];
+      expect(filename).toMatch(/\.webp$/);
+    });
+  });
+});

--- a/src/uploads/avatar-upload.service.ts
+++ b/src/uploads/avatar-upload.service.ts
@@ -1,7 +1,10 @@
 import { BadRequestException, Inject, Injectable } from '@nestjs/common';
 import { randomUUID } from 'crypto';
 import { UsersService } from '../users/users.service';
-import { STORAGE_ADAPTER, StorageAdapter } from './adapters/storage-adapter.interface';
+import {
+  STORAGE_ADAPTER,
+  StorageAdapter,
+} from './adapters/storage-adapter.interface';
 import { NoOpVirusScanHook } from './hooks/virus-scan.hook';
 
 const MIME_TO_EXT: Record<string, string> = {

--- a/src/uploads/avatar-upload.service.ts
+++ b/src/uploads/avatar-upload.service.ts
@@ -1,0 +1,57 @@
+import { BadRequestException, Inject, Injectable } from '@nestjs/common';
+import { randomUUID } from 'crypto';
+import { UsersService } from '../users/users.service';
+import { STORAGE_ADAPTER, StorageAdapter } from './adapters/storage-adapter.interface';
+import { NoOpVirusScanHook } from './hooks/virus-scan.hook';
+
+const MIME_TO_EXT: Record<string, string> = {
+  'image/jpeg': 'jpg',
+  'image/png': 'png',
+  'image/webp': 'webp',
+};
+
+const ALLOWED_MIMES = new Set(Object.keys(MIME_TO_EXT));
+const MAX_SIZE_BYTES = 2 * 1024 * 1024;
+
+@Injectable()
+export class AvatarUploadService {
+  constructor(
+    @Inject(STORAGE_ADAPTER) private readonly storage: StorageAdapter,
+    private readonly usersService: UsersService,
+    private readonly virusScan: NoOpVirusScanHook,
+  ) {}
+
+  async uploadAvatar(
+    userId: number,
+    file: Express.Multer.File,
+  ): Promise<{ avatarUrl: string }> {
+    if (!ALLOWED_MIMES.has(file.mimetype)) {
+      throw new BadRequestException({
+        message: 'File type not allowed. Accepted: jpeg, png, webp',
+        code: 'INVALID_FILE_TYPE',
+      });
+    }
+
+    if (file.size > MAX_SIZE_BYTES) {
+      throw new BadRequestException({
+        message: 'File too large. Maximum allowed size is 2 MB',
+        code: 'FILE_TOO_LARGE',
+      });
+    }
+
+    await this.virusScan.scan(file.buffer);
+
+    const ext = MIME_TO_EXT[file.mimetype];
+    const filename = `${randomUUID()}.${ext}`;
+
+    const user = await this.usersService.findById(userId);
+    if (user?.avatarUrl) {
+      await this.storage.delete(user.avatarUrl);
+    }
+
+    const avatarUrl = await this.storage.save(file.buffer, filename);
+    await this.usersService.updateProfile(userId, { avatarUrl });
+
+    return { avatarUrl };
+  }
+}

--- a/src/uploads/dto/avatar-upload-response.dto.ts
+++ b/src/uploads/dto/avatar-upload-response.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class AvatarUploadResponseDto {
+  @ApiProperty({ example: 'http://localhost:3000/uploads/avatars/uuid.jpg' })
+  avatarUrl: string;
+
+  @ApiProperty({ example: 'Avatar uploaded successfully' })
+  message: string;
+}

--- a/src/uploads/hooks/virus-scan.hook.ts
+++ b/src/uploads/hooks/virus-scan.hook.ts
@@ -1,0 +1,9 @@
+export interface VirusScanHook {
+  scan(buffer: Buffer): Promise<void>;
+}
+
+export class NoOpVirusScanHook implements VirusScanHook {
+  async scan(_buffer: Buffer): Promise<void> {
+    // No-op stub — replace with a real AV engine in production
+  }
+}

--- a/src/uploads/uploads.module.ts
+++ b/src/uploads/uploads.module.ts
@@ -1,0 +1,31 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { AvatarUploadController } from './avatar-upload.controller';
+import { AvatarUploadService } from './avatar-upload.service';
+import { LocalStorageAdapter } from './adapters/local-storage.adapter';
+import { S3StorageAdapter } from './adapters/s3-storage.adapter';
+import { NoOpVirusScanHook } from './hooks/virus-scan.hook';
+import { STORAGE_ADAPTER } from './adapters/storage-adapter.interface';
+import { UsersModule } from '../users/users.module';
+
+@Module({
+  imports: [ConfigModule, UsersModule],
+  controllers: [AvatarUploadController],
+  providers: [
+    AvatarUploadService,
+    NoOpVirusScanHook,
+    LocalStorageAdapter,
+    S3StorageAdapter,
+    {
+      provide: STORAGE_ADAPTER,
+      useFactory: (
+        config: ConfigService,
+        local: LocalStorageAdapter,
+        s3: S3StorageAdapter,
+      ) =>
+        config.get<string>('STORAGE_DRIVER', 'local') === 's3' ? s3 : local,
+      inject: [ConfigService, LocalStorageAdapter, S3StorageAdapter],
+    },
+  ],
+})
+export class UploadsModule {}


### PR DESCRIPTION
 feat: add avatar upload service with pluggable storage adapter

 Summary Adds POST /users/me/avatar (JWT-required multipart endpoint) that validates, stores, and persists an avatar image, replacing any existing one Implements a StorageAdapter interface with LocalStorageAdapter (default) and S3StorageAdapter (stub), selected at startup via STORAGE_DRIVER env var Adds a VirusScanHook no-op interface as a hook point for future AV integration Uploaded files are stored with a UUID filename (original name never used in path); old local file is deleted on replacement Serves uploaded files as static assets at /uploads/* via NestExpressApplication New env vars (see .env.example) Var	Default	Purpose STORAGE_DRIVER	local	local or s3 UPLOAD_DIR	./uploads	Root folder for local file storage PUBLIC_BASE_URL	http://localhost:3000	Base URL prepended to returned avatarUrl Test plan  POST /users/me/avatar without JWT returns 401  Upload a valid JPEG/PNG/WebP under 2 MB → 201 with avatarUrl persisted on profile  Upload a GIF or PDF → 400 with code INVALID_FILE_TYPE  Upload a file over 2 MB → 400 with code FILE_TOO_LARGE  Upload a second avatar → confirm old file is deleted from disk and new URL is saved  Check /uploads/avatars/<filename> is publicly reachable (no auth)  Verify filename in URL is a UUID, not the original upload name  npm test -- --testPathPattern=uploads → 14 tests pass. closes #24